### PR TITLE
feat: add basic ticket pdf generator

### DIFF
--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -5,6 +5,7 @@ import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../../common/SafeIcon';
 import TicketPreview from './TicketPreview';
 import supabase from '../../lib/supabase';
+import { downloadTicketsPDF } from '../../utils/pdfGenerator';
 
 // 🛠  Added FiInfo below to satisfy ESLint no-undef
 const {
@@ -545,8 +546,26 @@ const TicketTemplateSettings = () => {
   };
 
   const handleDownloadPreview = () => {
-    // Здесь будет логика скачивания билета в формате PDF
-    alert('Функция скачивания будет доступна в следующих обновлениях.');
+    if (lastSoldTicket) {
+      const orderData = {
+        orderNumber: lastSoldTicket.order_item?.order?.id,
+        event: {
+          title: lastSoldTicket.event?.title,
+          date: lastSoldTicket.event?.event_date,
+          location: lastSoldTicket.event?.location
+        },
+        seats: [
+          {
+            label: lastSoldTicket.seat
+              ? `${lastSoldTicket.seat.section} ряд ${lastSoldTicket.seat.row_number} место ${lastSoldTicket.seat.seat_number}`
+              : lastSoldTicket.zone
+                ? `Зона "${lastSoldTicket.zone.name}"`
+                : 'Общий вход'
+          }
+        ]
+      };
+      downloadTicketsPDF(orderData, 'ticket-preview.pdf');
+    }
   };
 
   const tabs = [

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -8,6 +8,7 @@ import EventWizard from '../components/events/EventWizard';
 import VenueDesigner from '../components/venue/VenueDesigner';
 import TicketTemplateSettings from '../components/admin/TicketTemplateSettings';
 import supabase from '../lib/supabase';
+import { downloadTicketsPDF } from '../utils/pdfGenerator';
 
 const {
   FiUsers,
@@ -778,6 +779,31 @@ const AdminPage = () => {
   const viewOrderDetails = (order) => {
     setOrderDetails(order);
     setShowOrderDetails(true);
+  };
+
+  const handleDownloadTickets = () => {
+    if (!orderDetails) return;
+    const event = orderDetails.order_items[0]?.ticket?.event;
+    const seats = orderDetails.order_items.map(item => {
+      const seat = item.ticket?.seat;
+      const zone = item.ticket?.zone;
+      if (seat) {
+        return { label: `${seat.section} ряд ${seat.row_number} место ${seat.seat_number}` };
+      }
+      if (zone) {
+        return { label: `Зона "${zone.name}"` };
+      }
+      return { label: 'Общий вход' };
+    });
+    downloadTicketsPDF({
+      orderNumber: orderDetails.id,
+      event: {
+        title: event?.title,
+        date: event?.event_date,
+        location: event?.location
+      },
+      seats
+    }, `order-${orderDetails.id}.pdf`);
   };
 
   const handleOrderAction = async (action, orderId, ticketIds = []) => {
@@ -2217,7 +2243,7 @@ const AdminPage = () => {
                             <SafeIcon icon={FiRefreshCw} className="w-4 h-4" />
                             {processingOrderAction ? 'Обработка...' : 'Вернуть деньги'}
                           </button>
-                          <button className="flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg">
+                          <button onClick={handleDownloadTickets} className="flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg">
                             <SafeIcon icon={FiDownload} className="w-4 h-4" />
                             Скачать билеты
                           </button>

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { FiCheck, FiDownload, FiHome } from 'react-icons/fi';
 import SafeIcon from '../common/SafeIcon';
+import { downloadTicketsPDF } from '../utils/pdfGenerator';
 
 const ThankYouPage = () => {
   const navigate = useNavigate();
@@ -44,6 +45,12 @@ const ThankYouPage = () => {
     }, 60000); // 1 минута
     return () => clearTimeout(timer);
   }, [navigate]);
+
+  const handleDownload = () => {
+    if (orderSummary) {
+      downloadTicketsPDF(orderSummary, `tickets-${orderNumber}.pdf`);
+    }
+  };
 
   return (
     <div className="min-h-screen bg-zinc-900 flex flex-col items-center justify-center px-4">
@@ -102,7 +109,7 @@ const ThankYouPage = () => {
         </div>
 
         <div className="flex flex-col sm:flex-row gap-4 mb-6">
-          <button className="flex-1 flex items-center justify-center gap-2 py-3 bg-yellow-500 text-black rounded-lg hover:bg-yellow-400 transition font-medium">
+          <button onClick={handleDownload} className="flex-1 flex items-center justify-center gap-2 py-3 bg-yellow-500 text-black rounded-lg hover:bg-yellow-400 transition font-medium">
             <SafeIcon icon={FiDownload} />
             <span>Скачать билеты</span>
           </button>

--- a/src/utils/pdfGenerator.js
+++ b/src/utils/pdfGenerator.js
@@ -1,0 +1,67 @@
+export function escapePdfString(str) {
+  return String(str)
+    .replace(/\\/g, '\\\\')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)');
+}
+
+function createPdf(textLines) {
+  const lines = Array.isArray(textLines) ? textLines : [textLines];
+  const escaped = lines.map(escapePdfString);
+  const contentStream = [
+    'BT',
+    '/F1 12 Tf',
+    '50 780 Td',
+    escaped.map((line, idx) => `${idx ? '0 -14 Td' : ''}(${line}) Tj`).join('\n'),
+    'ET'
+  ].join('\n');
+
+  const objects = [];
+  objects.push('1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj');
+  objects.push('2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj');
+  objects.push('3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj');
+  objects.push(`4 0 obj<</Length ${contentStream.length}>>stream\n${contentStream}\nendstream endobj`);
+  objects.push('5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj');
+
+  let pdf = '%PDF-1.1\n';
+  const offsets = [];
+  for (const obj of objects) {
+    offsets.push(pdf.length);
+    pdf += obj + '\n';
+  }
+  const xrefStart = pdf.length;
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += '0000000000 65535 f \n';
+  for (const offset of offsets) {
+    pdf += `${String(offset).padStart(10, '0')} 00000 n \n`;
+  }
+  pdf += `trailer<</Size ${objects.length + 1}/Root 1 0 R>>\nstartxref\n${xrefStart}\n%%EOF`;
+  return pdf;
+}
+
+export function downloadTicketsPDF(order, fileName = 'tickets.pdf') {
+  if (!order) return;
+  const lines = [];
+  if (order.orderNumber) lines.push(`Order: ${order.orderNumber}`);
+  if (order.event) {
+    if (order.event.title) lines.push(`Event: ${order.event.title}`);
+    if (order.event.date) lines.push(`Date: ${order.event.date}`);
+    if (order.event.location) lines.push(`Location: ${order.event.location}`);
+  }
+  if (Array.isArray(order.seats)) {
+    order.seats.forEach((seat, idx) => {
+      const label = seat?.label || seat?.number || seat?.id || `Seat ${idx + 1}`;
+      lines.push(`Seat ${idx + 1}: ${label}`);
+    });
+  }
+  const pdfString = createPdf(lines);
+  const blob = new Blob([pdfString], { type: 'application/pdf' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- generate minimal PDF tickets without external deps
- hook PDF generation into Thank You page, order details, and template preview

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689557fe17488322a9dab2ddc01e65f0