### PR TITLE
feat: integrate ticket template with real ticket data

### DIFF
--- a/src/components/admin/TicketPreview.jsx
+++ b/src/components/admin/TicketPreview.jsx
@@ -5,7 +5,7 @@ import SafeIcon from '../../common/SafeIcon';
 
 const { FiDownload, FiRefreshCw } = FiIcons;
 
-const TicketPreview = ({ settings, onDownload, onRefresh }) => {
+const TicketPreview = ({ settings, onDownload, onRefresh, ticketData }) => {
   const sampleTicketData = {
     eventTitle: 'Концерт группы "Пример"',
     eventDate: '15 декабря 2024',
@@ -17,6 +17,9 @@ const TicketPreview = ({ settings, onDownload, onRefresh }) => {
     customerName: 'Иван Петров',
     ticketNumber: 'T-001'
   };
+
+  // Используем реальные данные билета, если они переданы из родительского компонента
+  const data = ticketData || sampleTicketData;
 
   const getQRSize = () => {
     switch (settings.qrCode.size) {
@@ -118,17 +121,17 @@ const TicketPreview = ({ settings, onDownload, onRefresh }) => {
                   fontSize: settings.design.fontSize === 'large' ? '24px' : settings.design.fontSize === 'small' ? '16px' : '20px'
                 }}
               >
-                {sampleTicketData.eventTitle}
+                {data.eventTitle}
               </h1>
               {settings.ticketContent.showDateTime && (
                 <div className="mb-2">
-                  <div className="font-medium">{sampleTicketData.eventDate}</div>
-                  <div className="text-sm opacity-75">{sampleTicketData.eventTime}</div>
+                  <div className="font-medium">{data.eventDate}</div>
+                  <div className="text-sm opacity-75">{data.eventTime}</div>
                 </div>
               )}
               {settings.ticketContent.showVenueInfo && (
                 <div className="mb-2 text-sm opacity-75">
-                  {sampleTicketData.eventLocation}
+                  {data.eventLocation}
                 </div>
               )}
             </div>
@@ -141,24 +144,24 @@ const TicketPreview = ({ settings, onDownload, onRefresh }) => {
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
                 <span>Билет №:</span>
-                <span className="font-mono">{sampleTicketData.ticketNumber}</span>
+                <span className="font-mono">{data.ticketNumber}</span>
               </div>
               <div className="flex justify-between">
                 <span>Заказ №:</span>
-                <span className="font-mono">{sampleTicketData.orderNumber}</span>
+                <span className="font-mono">{data.orderNumber}</span>
               </div>
               <div className="flex justify-between">
                 <span>Место:</span>
-                <span>{sampleTicketData.seatInfo}</span>
+                <span>{data.seatInfo}</span>
               </div>
               {settings.ticketContent.showPrice && (
                 <div className="flex justify-between">
                   <span>Цена:</span>
-                  <span 
+                  <span
                     className="font-bold"
                     style={{ color: settings.colorScheme.accent }}
                   >
-                    {sampleTicketData.price}
+                    {data.price}
                   </span>
                 </div>
               )}

--- a/src/utils/pdfGenerator.js
+++ b/src/utils/pdfGenerator.js
@@ -41,12 +41,27 @@ function createPdf(textLines) {
 
 export function downloadTicketsPDF(order, fileName = 'tickets.pdf') {
   if (!order) return;
+
+  // Загружаем настройки шаблона, чтобы применить их при генерации PDF
+  let settings = {};
+  try {
+    const stored = localStorage.getItem('ticketTemplateSettings');
+    if (stored) settings = JSON.parse(stored);
+  } catch {
+    // игнорируем ошибки парсинга и используем настройки по умолчанию
+  }
+
   const lines = [];
+  if (settings.companyInfo?.name) lines.push(settings.companyInfo.name);
   if (order.orderNumber) lines.push(`Order: ${order.orderNumber}`);
   if (order.event) {
     if (order.event.title) lines.push(`Event: ${order.event.title}`);
-    if (order.event.date) lines.push(`Date: ${order.event.date}`);
-    if (order.event.location) lines.push(`Location: ${order.event.location}`);
+    if (settings.ticketContent?.showDateTime && order.event.date) {
+      lines.push(`Date: ${order.event.date}`);
+    }
+    if (settings.ticketContent?.showVenueInfo && order.event.location) {
+      lines.push(`Location: ${order.event.location}`);
+    }
   }
   if (Array.isArray(order.seats)) {
     order.seats.forEach((seat, idx) => {
@@ -54,6 +69,16 @@ export function downloadTicketsPDF(order, fileName = 'tickets.pdf') {
       lines.push(`Seat ${idx + 1}: ${label}`);
     });
   }
+  if (settings.ticketContent?.showPrice && order.totalPrice) {
+    lines.push(`Total: ${order.totalPrice}`);
+  }
+  if (settings.ticketContent?.customInstructions) {
+    lines.push(settings.ticketContent.customInstructions);
+  }
+  if (settings.companyInfo?.website) {
+    lines.push(settings.companyInfo.website);
+  }
+
   const pdfString = createPdf(lines);
   const blob = new Blob([pdfString], { type: 'application/pdf' });
   const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- generate ticket preview with real event information using latest sold ticket
- apply saved template settings when creating ticket PDFs, injecting event and seat details
- support real ticket data in preview component

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68955ada4cd48322a074ae267eae34ad