### PR TITLE
feat: integrate ticket template with real ticket data

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "react-icons": "^5.4.0",
     "echarts": "^5.5.0",
     "echarts-for-react": "^3.0.2",
-    "date-fns": "4.1.0"
+    "date-fns": "4.1.0",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/components/admin/TicketPreview.jsx
+++ b/src/components/admin/TicketPreview.jsx
@@ -5,7 +5,7 @@ import SafeIcon from '../../common/SafeIcon';
 
 const { FiDownload, FiRefreshCw } = FiIcons;
 
-const TicketPreview = ({ settings, onDownload, onRefresh }) => {
+const TicketPreview = ({ settings, onDownload, onRefresh, ticketData, previewRef }) => {
   const sampleTicketData = {
     eventTitle: 'Концерт группы "Пример"',
     eventDate: '15 декабря 2024',
@@ -17,6 +17,9 @@ const TicketPreview = ({ settings, onDownload, onRefresh }) => {
     customerName: 'Иван Петров',
     ticketNumber: 'T-001'
   };
+
+  // Используем реальные данные билета, если они переданы из родительского компонента
+  const data = ticketData || sampleTicketData;
 
   const getQRSize = () => {
     switch (settings.qrCode.size) {
@@ -69,7 +72,8 @@ const TicketPreview = ({ settings, onDownload, onRefresh }) => {
       
       {/* Ticket Preview */}
       <div className="bg-zinc-100 dark:bg-zinc-800 p-6 rounded-lg">
-        <div 
+        <div
+          ref={previewRef}
           className="relative mx-auto rounded-lg shadow-lg overflow-hidden"
           style={{
             width: '400px',
@@ -118,17 +122,17 @@ const TicketPreview = ({ settings, onDownload, onRefresh }) => {
                   fontSize: settings.design.fontSize === 'large' ? '24px' : settings.design.fontSize === 'small' ? '16px' : '20px'
                 }}
               >
-                {sampleTicketData.eventTitle}
+                {data.eventTitle}
               </h1>
               {settings.ticketContent.showDateTime && (
                 <div className="mb-2">
-                  <div className="font-medium">{sampleTicketData.eventDate}</div>
-                  <div className="text-sm opacity-75">{sampleTicketData.eventTime}</div>
+                  <div className="font-medium">{data.eventDate}</div>
+                  <div className="text-sm opacity-75">{data.eventTime}</div>
                 </div>
               )}
               {settings.ticketContent.showVenueInfo && (
                 <div className="mb-2 text-sm opacity-75">
-                  {sampleTicketData.eventLocation}
+                  {data.eventLocation}
                 </div>
               )}
             </div>
@@ -141,24 +145,24 @@ const TicketPreview = ({ settings, onDownload, onRefresh }) => {
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
                 <span>Билет №:</span>
-                <span className="font-mono">{sampleTicketData.ticketNumber}</span>
+                <span className="font-mono">{data.ticketNumber}</span>
               </div>
               <div className="flex justify-between">
                 <span>Заказ №:</span>
-                <span className="font-mono">{sampleTicketData.orderNumber}</span>
+                <span className="font-mono">{data.orderNumber}</span>
               </div>
               <div className="flex justify-between">
                 <span>Место:</span>
-                <span>{sampleTicketData.seatInfo}</span>
+                <span>{data.seatInfo}</span>
               </div>
               {settings.ticketContent.showPrice && (
                 <div className="flex justify-between">
                   <span>Цена:</span>
-                  <span 
+                  <span
                     className="font-bold"
                     style={{ color: settings.colorScheme.accent }}
                   >
-                    {sampleTicketData.price}
+                    {data.price}
                   </span>
                 </div>
               )}


### PR DESCRIPTION
## Summary
- capture ticket preview DOM and export PDF using current template
- expose TicketPreview element via ref to apply saved styles and real data in generated PDF
- add html2canvas and jsPDF dependencies for template-based PDF creation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68955ada4cd48322a074ae267eae34ad