### PR TITLE
Handle PDF font loading errors with path-based local fallback

### DIFF
--- a/src/utils/pdfGenerator.js
+++ b/src/utils/pdfGenerator.js
@@ -1,6 +1,9 @@
-import { PDFDocument, rgb } from 'pdf-lib';
+import { PDFDocument, rgb, StandardFonts } from 'pdf-lib';
 import QRCode from 'qrcode';
 import fontkit from '@pdf-lib/fontkit';
+// Optional local DejaVuSans font path for offline usage. Place the font file in
+// `public/fonts/DejaVuSans.ttf` at build time if needed.
+const localFontUrl = '/fonts/DejaVuSans.ttf';
 
 function hexToRgb(hex) {
   const value = hex?.replace('#', '') || '000000';
@@ -205,8 +208,32 @@ export async function downloadTicketsPDF(order, fileName = 'tickets.pdf') {
 
   const pdfDoc = await PDFDocument.create();
   pdfDoc.registerFontkit(fontkit);
-  const fontBytes = await fetch('https://pdf-lib.github.io/assets/ttf/DejaVuSans.ttf').then((res) => res.arrayBuffer());
-  const font = await pdfDoc.embedFont(fontBytes);
+
+  const cdnFontUrl = 'https://cdn.jsdelivr.net/npm/dejavu-fonts-ttf@2.37/ttf/DejaVuSans.ttf';
+  let fontBytes;
+  try {
+    const response = await fetch(cdnFontUrl);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    fontBytes = await response.arrayBuffer();
+  } catch (err) {
+    console.error('Failed to load font from CDN:', err);
+    console.warn('Falling back to locally stored DejaVuSans font.');
+    try {
+      const localResponse = await fetch(localFontUrl);
+      if (!localResponse.ok) throw new Error(`HTTP ${localResponse.status}`);
+      fontBytes = await localResponse.arrayBuffer();
+    } catch (localErr) {
+      console.error('Failed to load local fallback font:', localErr);
+    }
+  }
+
+  let font;
+  if (fontBytes) {
+    font = await pdfDoc.embedFont(fontBytes);
+  } else {
+    console.warn('Using standard Helvetica font as a last resort.');
+    font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  }
 
   if (Array.isArray(order.seats) && order.seats.length > 0) {
     for (const seat of order.seats) {


### PR DESCRIPTION
## Summary
- remove bundled DejaVuSans font and reference optional path for offline usage
- keep CDN font loading with logged errors and Helvetica fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ba4b33cb48322895cb173b2062ff2