### PR TITLE
fix: specify ticket joins to avoid PGRST201

### DIFF
--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -178,7 +178,7 @@ const TicketTemplateSettings = () => {
             event:events(title, event_date, location),
             zone:zones(name),
             seat:single_seats(row_number, seat_number, section),
-            order_item:order_items(
+            order_item:order_items!tickets_order_item_id_fkey(
               unit_price,
               order:orders(id, user_id, total_price)
             )

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -356,7 +356,7 @@ const AdminPage = () => {
           *,
           order_items:order_items(
             *,
-            ticket:tickets(
+            ticket:tickets!fk_order_items_ticket_id(
               *,
               event:events(id, title, event_date)
             )
@@ -405,7 +405,7 @@ const AdminPage = () => {
         .select(`
           total_price,
           order_items:order_items(
-            ticket:tickets(
+            ticket:tickets!fk_order_items_ticket_id(
               event:events(category)
             )
           )

--- a/src/services/ticketService.js
+++ b/src/services/ticketService.js
@@ -491,7 +491,7 @@ export const getOrderDetails = async (orderId) => {
         *,
         order_items:order_items(
           *,
-          ticket:tickets(
+          ticket:tickets!fk_order_items_ticket_id(
             *,
             event:events(id, title, event_date, location),
             zone:zones(id, name, category:seat_categories(*)),
@@ -521,7 +521,7 @@ export const getAllOrders = async () => {
         order_items:order_items(
           id,
           unit_price,
-          ticket:tickets(
+          ticket:tickets!fk_order_items_ticket_id(
             id,
             status,
             event:events(title, event_date)


### PR DESCRIPTION
## Summary
- ensure dashboard queries join tickets via `fk_order_items_ticket_id`
- align ticket template query with `tickets_order_item_id_fkey`
- adjust ticket service order queries for explicit joins

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ba76093c08322b8937b7894106154