### PR TITLE
Ensure ticket PDFs use current template settings

### DIFF
--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -578,27 +578,31 @@ const TicketTemplateSettings = () => {
     }
   };
 
-  const handleDownloadPreview = () => {
-    if (lastSoldTicket) {
-      const orderData = {
-        orderNumber: lastSoldTicket.order_item?.order?.id,
-        event: {
-          title: lastSoldTicket.event?.title,
-          date: lastSoldTicket.event?.event_date,
-          location: lastSoldTicket.event?.location
-        },
-        seats: [
-          {
-            label: lastSoldTicket.seat
-              ? `${lastSoldTicket.seat.section} ряд ${lastSoldTicket.seat.row_number} место ${lastSoldTicket.seat.seat_number}`
-              : lastSoldTicket.zone
-                ? `Зона "${lastSoldTicket.zone.name}"`
-                : 'Общий вход'
-          }
-        ]
-      };
-      downloadTicketsPDF(orderData, 'ticket-preview.pdf');
-    }
+  const handleDownloadPreview = async () => {
+    if (!lastSoldTicket) return;
+
+    // Ensure current settings are saved before generating preview
+    await saveSettings();
+
+    const orderData = {
+      orderNumber: lastSoldTicket.order_item?.order?.id,
+      event: {
+        title: lastSoldTicket.event?.title,
+        date: lastSoldTicket.event?.event_date,
+        location: lastSoldTicket.event?.location
+      },
+      seats: [
+        {
+          label: lastSoldTicket.seat
+            ? `${lastSoldTicket.seat.section} ряд ${lastSoldTicket.seat.row_number} место ${lastSoldTicket.seat.seat_number}`
+            : lastSoldTicket.zone
+              ? `Зона "${lastSoldTicket.zone.name}"`
+              : 'Общий вход'
+        }
+      ]
+    };
+
+    downloadTicketsPDF(orderData, 'ticket-preview.pdf', templateSettings);
   };
 
   const tabs = [

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -795,6 +795,14 @@ const AdminPage = () => {
       }
       return { label: 'Общий вход' };
     });
+    let templateSettings;
+    try {
+      const stored = localStorage.getItem('ticketTemplateSettings');
+      if (stored) templateSettings = JSON.parse(stored);
+    } catch (err) {
+      console.error('Error parsing ticket template settings:', err);
+    }
+
     downloadTicketsPDF({
       orderNumber: orderDetails.id,
       event: {
@@ -803,7 +811,7 @@ const AdminPage = () => {
         location: event?.location
       },
       seats
-    }, `order-${orderDetails.id}.pdf`);
+    }, `order-${orderDetails.id}.pdf`, templateSettings);
   };
 
   const handleOrderAction = async (action, orderId, ticketIds = []) => {

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -8,6 +8,7 @@ import { downloadTicketsPDF } from '../utils/pdfGenerator';
 const ThankYouPage = () => {
   const navigate = useNavigate();
   const [orderSummary, setOrderSummary] = useState(null);
+  const [templateSettings, setTemplateSettings] = useState(null);
   const orderNumber = orderSummary?.orderNumber || `TW-${Math.floor(100000 + Math.random() * 900000)}`;
 
   // Load order summary from sessionStorage
@@ -18,6 +19,18 @@ const ThankYouPage = () => {
         setOrderSummary(JSON.parse(storedOrderSummary));
       } catch (error) {
         console.error('Error parsing order summary:', error);
+      }
+    }
+  }, []);
+
+  // Load template settings from localStorage
+  useEffect(() => {
+    const storedSettings = localStorage.getItem('ticketTemplateSettings');
+    if (storedSettings) {
+      try {
+        setTemplateSettings(JSON.parse(storedSettings));
+      } catch (error) {
+        console.error('Error parsing template settings:', error);
       }
     }
   }, []);
@@ -48,7 +61,7 @@ const ThankYouPage = () => {
 
   const handleDownload = () => {
     if (orderSummary) {
-      downloadTicketsPDF(orderSummary, `tickets-${orderNumber}.pdf`);
+      downloadTicketsPDF(orderSummary, `tickets-${orderNumber}.pdf`, templateSettings);
     }
   };
 

--- a/src/utils/pdfGenerator.js
+++ b/src/utils/pdfGenerator.js
@@ -195,15 +195,17 @@ async function drawTicketPage(pdfDoc, order, seat, settings, font) {
   }
 }
 
-export async function downloadTicketsPDF(order, fileName = 'tickets.pdf') {
+export async function downloadTicketsPDF(order, fileName = 'tickets.pdf', templateSettings) {
   if (!order) return;
 
-  let settings = {};
-  try {
-    const stored = localStorage.getItem('ticketTemplateSettings');
-    if (stored) settings = JSON.parse(stored);
-  } catch {
-    // ignore
+  let settings = templateSettings;
+  if (!settings) {
+    try {
+      const stored = localStorage.getItem('ticketTemplateSettings');
+      if (stored) settings = JSON.parse(stored);
+    } catch {
+      // ignore
+    }
   }
 
   const pdfDoc = await PDFDocument.create();


### PR DESCRIPTION
## Summary
- allow passing template settings into `downloadTicketsPDF`
- load saved template settings for downloads on admin and thank-you pages
- save and pass current settings when generating ticket previews

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ba8d802c8832281aa9372b7b6afe3