### PR TITLE
feat: add event note support

### DIFF
--- a/migrations/20231201_add_note_to_events.sql
+++ b/migrations/20231201_add_note_to_events.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events ADD COLUMN note TEXT;

--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -175,7 +175,7 @@ const TicketTemplateSettings = () => {
           .from('tickets')
           .select(`
             *,
-            event:events(title, event_date, location),
+            event:events(title, event_date, location, note),
             zone:zones(name),
             seat:single_seats(row_number, seat_number, section),
             order_item:order_items!tickets_order_item_id_fkey(
@@ -552,7 +552,7 @@ const TicketTemplateSettings = () => {
         .from('tickets')
         .select(`
           *,
-          event:events(title, event_date, location),
+          event:events(title, event_date, location, note),
           zone:zones(name),
           seat:single_seats(row_number, seat_number, section),
           order_item:order_items(
@@ -589,7 +589,8 @@ const TicketTemplateSettings = () => {
       event: {
         title: lastSoldTicket.event?.title,
         date: lastSoldTicket.event?.event_date,
-        location: lastSoldTicket.event?.location
+        location: lastSoldTicket.event?.location,
+        note: lastSoldTicket.event?.note
       },
       seats: [
         {

--- a/src/components/events/EventWizard.jsx
+++ b/src/components/events/EventWizard.jsx
@@ -283,7 +283,8 @@ const EventWizard = ({ onCancel, eventToEdit = null, onEventSaved }) => {
     event_date: new Date().toISOString().slice(0, 16), // Format for datetime-local
     image: 'https://placehold.co/600x400/333/FFF?text=Event',
     venue_id: null,
-    prices: {}
+    prices: {},
+    note: ''
   });
 
   // References for sections
@@ -404,7 +405,8 @@ const EventWizard = ({ onCancel, eventToEdit = null, onEventSaved }) => {
         location: event.location || '',
         image: event.image || 'https://placehold.co/600x400/333/FFF?text=Event',
         venue_id: event.venue_id || null,
-        prices: {}
+        prices: {},
+        note: event.note || ''
       };
 
       console.log("Formatted event data:", formattedEventData);
@@ -612,6 +614,7 @@ const EventWizard = ({ onCancel, eventToEdit = null, onEventSaved }) => {
         event_date: formattedDate,
         image: eventData.image,
         venue_id: eventData.venue_id || null,
+        note: eventData.note || '',
         published_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
         prices: eventData.prices
@@ -639,6 +642,7 @@ const EventWizard = ({ onCancel, eventToEdit = null, onEventSaved }) => {
             event_date: eventPayload.event_date,
             image: eventPayload.image,
             venue_id: eventPayload.venue_id,
+            note: eventPayload.note,
             updated_at: eventPayload.updated_at,
             status: 'draft' // Set to draft before creating tickets
           })
@@ -706,6 +710,7 @@ const EventWizard = ({ onCancel, eventToEdit = null, onEventSaved }) => {
             event_date: eventPayload.event_date,
             image: eventPayload.image,
             venue_id: eventPayload.venue_id,
+            note: eventPayload.note,
             status: 'draft', // Start as draft
             published_at: eventPayload.published_at,
             created_at: eventPayload.created_at,
@@ -1027,6 +1032,20 @@ const EventWizard = ({ onCancel, eventToEdit = null, onEventSaved }) => {
                   />
                 </div>
 
+                {/* Note */}
+                <div className="md:col-span-2">
+                  <label className="block text-sm font-medium text-gray-400 mb-1">
+                    Note
+                  </label>
+                  <textarea
+                    value={eventData.note}
+                    onChange={(e) => handleChange('note', e.target.value)}
+                    rows="3"
+                    className="w-full px-4 py-2 bg-zinc-700 border border-zinc-600 rounded-lg text-white focus:outline-none focus:border-yellow-400"
+                    placeholder="Additional notes or terms (optional)"
+                  />
+                </div>
+
                 {/* ОБНОВЛЕННЫЙ блок изображения с возможностью загрузки */}
                 <div className="md:col-span-2">
                   <label className="block text-sm font-medium text-gray-400 mb-1">
@@ -1318,6 +1337,12 @@ const EventWizard = ({ onCancel, eventToEdit = null, onEventSaved }) => {
                       <div>
                         <span className="text-gray-400">Genre:</span>
                         <span className="text-white ml-2">{eventData.genre}</span>
+                      </div>
+                    )}
+                    {eventData.note && (
+                      <div className="md:col-span-2">
+                        <span className="text-gray-400">Note:</span>
+                        <span className="text-white ml-2">{eventData.note}</span>
                       </div>
                     )}
                   </div>

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -358,7 +358,7 @@ const AdminPage = () => {
             *,
             ticket:tickets!fk_order_items_ticket_id(
               *,
-              event:events(id, title, event_date)
+              event:events(id, title, event_date, note)
             )
           )
         `)
@@ -406,7 +406,7 @@ const AdminPage = () => {
           total_price,
           order_items:order_items(
             ticket:tickets!fk_order_items_ticket_id(
-              event:events(category)
+              event:events(category, note)
             )
           )
         `)
@@ -476,7 +476,7 @@ const AdminPage = () => {
       // Статистика билетов
       const { data: ticketsData, error: ticketsError } = await supabase
         .from('tickets')
-        .select('status, event:events(title)');
+        .select('status, event:events(title, note)');
 
       if (ticketsError) throw ticketsError;
 
@@ -740,7 +740,7 @@ const AdminPage = () => {
           .from('tickets')
           .select(`
             *,
-            event:events(id, title, event_date),
+            event:events(id, title, event_date, note),
             zone:zones(id, name),
             seat:single_seats(id, row_number, seat_number, section)
           `)
@@ -808,7 +808,8 @@ const AdminPage = () => {
       event: {
         title: event?.title,
         date: event?.event_date,
-        location: event?.location
+        location: event?.location,
+        note: event?.note
       },
       seats
     }, `order-${orderDetails.id}.pdf`, templateSettings);

--- a/src/pages/VenuePage.jsx
+++ b/src/pages/VenuePage.jsx
@@ -428,12 +428,13 @@ console.log('🚀 Proceeding to checkout with seats:',seatsForCheckout);
 
 // Store selected seats in sessionStorage to access them in checkout
 sessionStorage.setItem('selectedSeats',JSON.stringify(seatsForCheckout));
-sessionStorage.setItem('eventDetails',JSON.stringify({
-id: event.id,
-title: event.title,
-date: event.event_date,
-location: event.location,
-venue: venue?.name
+  sessionStorage.setItem('eventDetails',JSON.stringify({
+  id: event.id,
+  title: event.title,
+  date: event.event_date,
+  location: event.location,
+  venue: venue?.name,
+  note: event.note
 }));
 
 navigate('/checkout');

--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -173,6 +173,7 @@ export const createEvent = async (eventData) => {
         event_date: eventData.event_date,
         image: eventData.image,
         venue_id: eventData.venue_id,
+        note: eventData.note || null,
         status: 'draft', // Start as draft
         published_at: new Date().toISOString(),
         created_at: new Date().toISOString(),
@@ -260,6 +261,7 @@ export const updateEvent = async (eventId, eventData) => {
         event_date: eventData.event_date,
         image: eventData.image,
         venue_id: eventData.venue_id,
+        note: eventData.note || null,
         updated_at: new Date().toISOString()
       })
       .eq('id', eventId)

--- a/src/services/ticketService.js
+++ b/src/services/ticketService.js
@@ -493,7 +493,7 @@ export const getOrderDetails = async (orderId) => {
           *,
           ticket:tickets!fk_order_items_ticket_id(
             *,
-            event:events(id, title, event_date, location),
+            event:events(id, title, event_date, location, note),
             zone:zones(id, name, category:seat_categories(*)),
             seat:single_seats(id, row_number, seat_number, section, category:seat_categories(*))
           )
@@ -524,7 +524,7 @@ export const getAllOrders = async () => {
           ticket:tickets!fk_order_items_ticket_id(
             id,
             status,
-            event:events(title, event_date)
+            event:events(title, event_date, note)
           )
         )
       `)

--- a/src/utils/pdfGenerator.js
+++ b/src/utils/pdfGenerator.js
@@ -205,10 +205,11 @@ async function drawTicketPage(pdfDoc, order, seat, settings, font) {
   if (design.showQRCode && ['bottom-left', 'bottom-right'].includes(qrCode.position)) {
     termsY += qrSize + 10;
   }
-  const termsText = [
-    ticketContent.customInstructions,
-    ticketContent.termsAndConditions
-  ].filter(Boolean).join(' ');
+  const termsText =
+    order.event?.note ||
+    [ticketContent.customInstructions, ticketContent.termsAndConditions]
+      .filter(Boolean)
+      .join(' ');
   if (termsText) {
     page.drawText(termsText, {
       x: cardX + padding,


### PR DESCRIPTION
## Summary
- add SQL migration for event `note` column
- support optional note in event creation flow and persistence
- include event notes in order queries and render on ticket PDFs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bbfc95cd48322beeb44d399855f06