### PR TITLE
Standardize ticket date formatting with date-fns

### DIFF
--- a/src/components/admin/TicketPreview.jsx
+++ b/src/components/admin/TicketPreview.jsx
@@ -2,14 +2,16 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../../common/SafeIcon';
+import { formatDateTime } from '../../utils/formatDateTime';
 
 const { FiDownload, FiRefreshCw } = FiIcons;
 
 const TicketPreview = ({ settings, onDownload, onRefresh, ticketData }) => {
+  const { date: sampleDate, time: sampleTime } = formatDateTime('2024-12-15T20:00:00');
   const sampleTicketData = {
     eventTitle: 'Концерт группы "Пример"',
-    eventDate: '15 декабря 2024',
-    eventTime: '20:00',
+    eventDate: sampleDate,
+    eventTime: sampleTime,
     eventLocation: 'Концертный зал "Олимпийский"',
     orderNumber: 'TW-123456',
     seatInfo: 'Партер, ряд 5, место 12',

--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -6,6 +6,7 @@ import SafeIcon from '../../common/SafeIcon';
 import TicketPreview from './TicketPreview';
 import supabase from '../../lib/supabase';
 import { downloadTicketsPDF } from '../../utils/pdfGenerator';
+import { formatDateTime } from '../../utils/formatDateTime';
 
 // 🛠  Added FiInfo below to satisfy ESLint no-undef
 const {
@@ -42,9 +43,9 @@ const TicketTemplateSettings = () => {
     let eventDate = '';
     let eventTime = '';
     if (eventDateRaw) {
-      const dateObj = new Date(eventDateRaw);
-      eventDate = dateObj.toLocaleDateString('ru-RU');
-      eventTime = dateObj.toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' });
+      const { date, time } = formatDateTime(eventDateRaw);
+      eventDate = date;
+      eventTime = time;
     }
     return {
       eventTitle: lastSoldTicket.event?.title || '',

--- a/src/utils/formatDateTime.js
+++ b/src/utils/formatDateTime.js
@@ -1,0 +1,26 @@
+import { format, parseISO } from 'date-fns';
+import { enUS, ru } from 'date-fns/locale';
+
+const localeMap = {
+  'en-US': enUS,
+  'ru-RU': ru
+};
+
+export function formatDateTime(dateInput, localeCode = (typeof navigator !== 'undefined' && navigator.language) ? navigator.language : 'en-US') {
+  try {
+    const date = typeof dateInput === 'string' ? parseISO(dateInput) : new Date(dateInput);
+    if (isNaN(date)) {
+      return { date: String(dateInput), time: '', dateTime: String(dateInput) };
+    }
+    const locale = localeMap[localeCode] || localeMap['en-US'];
+    return {
+      date: format(date, 'P', { locale }),
+      time: format(date, 'p', { locale }),
+      dateTime: format(date, 'Pp', { locale })
+    };
+  } catch {
+    return { date: String(dateInput), time: '', dateTime: String(dateInput) };
+  }
+}
+
+export default formatDateTime;

--- a/src/utils/pdfGenerator.js
+++ b/src/utils/pdfGenerator.js
@@ -2,6 +2,7 @@ import { PDFDocument, rgb, StandardFonts } from 'pdf-lib';
 import QRCode from 'qrcode';
 import fontkit from '@pdf-lib/fontkit';
 import DejaVuSansBase64 from '../assets/DejaVuSansBase64.js';
+import { formatDateTime } from './formatDateTime.js';
 
 function base64ToUint8Array(base64) {
   const binaryString =
@@ -153,7 +154,8 @@ async function drawTicketPage(pdfDoc, order, seat, settings, font) {
     cursorY -= fontSize + 8;
   }
   if (ticketContent.showDateTime && order.event?.date) {
-    page.drawText(String(order.event.date), {
+    const { dateTime } = formatDateTime(order.event.date);
+    page.drawText(dateTime, {
       x: cardX + padding,
       y: cursorY,
       size: fontSize,


### PR DESCRIPTION
## Summary
- add shared `formatDateTime` utility using date-fns for locale-aware date and time strings
- use the helper when rendering dates in generated ticket PDFs
- apply the same formatting in admin ticket previews and sample data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bc549151c83229a3e076ee6a0c0e0