### PR TITLE
feat: replace template tab with layout settings

### DIFF
--- a/src/components/admin/TicketLayoutSettings.jsx
+++ b/src/components/admin/TicketLayoutSettings.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import TicketPreview from './TicketPreview';
+
+const TicketLayoutSettings = ({ settings, onDownloadPreview, onRefreshPreview, ticketData }) => {
+  return (
+    <div className="space-y-6">
+      <TicketPreview
+        settings={settings}
+        onDownload={onDownloadPreview}
+        onRefresh={onRefreshPreview}
+        ticketData={ticketData}
+      />
+    </div>
+  );
+};
+
+export default TicketLayoutSettings;

--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -5,6 +5,7 @@ import SafeIcon from '../../common/SafeIcon';
 import supabase from '../../lib/supabase';
 import { downloadTicketsPDF } from '../../utils/pdfGenerator';
 import { formatDateTime } from '../../utils/formatDateTime';
+import TicketLayoutSettings from './TicketLayoutSettings';
 
 const {
   FiSave,
@@ -13,6 +14,7 @@ const {
   FiServer,
   FiEye,
   FiEyeOff,
+  FiLayout,
 } = FiIcons;
 
 const TicketTemplateSettings = () => {
@@ -597,6 +599,7 @@ const TicketTemplateSettings = () => {
   };
 
   const tabs = [
+    { id: 'layout', label: 'Макет билета', icon: FiLayout },
     { id: 'smtp', label: 'SMTP настройки', icon: FiServer },
     { id: 'email', label: 'Email шаблоны', icon: FiMail }
   ];
@@ -632,6 +635,16 @@ const TicketTemplateSettings = () => {
         <div className="bg-green-500/10 border border-green-500 text-green-500 p-4 rounded-lg">
           Настройки успешно сохранены!
         </div>
+      )}
+
+      {/* Ticket Layout Tab */}
+      {activeTab === 'layout' && (
+        <TicketLayoutSettings
+          settings={templateSettings}
+          onDownloadPreview={handleDownloadPreview}
+          onRefreshPreview={handleRefreshPreview}
+          ticketData={previewTicketData}
+        />
       )}
 
       {/* SMTP Settings Tab */}


### PR DESCRIPTION
## Summary
- add dedicated `Макет билета` tab for layout settings
- remove obsolete template tab usage
- introduce `TicketLayoutSettings` component to render ticket previews

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bd53a9ba0832282191593e534feca