### PR TITLE
Add basic PDF generation test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# TicketWayzV3
+
+This project uses [Vite](https://vitejs.dev/) for development and the built-in Node.js test runner for unit tests.
+
+## Testing
+
+Run the test suite:
+
+```bash
+npm test
+```
+
+This executes the Node.js test runner and verifies basic PDF generation utilities.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "npm run lint && vite build",
     "lint": "eslint .",
     "lint:error": "eslint . --quiet",
+    "test": "node --test",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/utils/pdfGenerator.test.js
+++ b/src/utils/pdfGenerator.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+import { drawTicketPage } from './pdfGenerator.js';
+
+test('drawTicketPage adds a page to the PDF document', async () => {
+  const pdfDoc = await PDFDocument.create();
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const order = { event: {} };
+  const settings = { design: { showQRCode: false } };
+
+  await drawTicketPage(pdfDoc, order, null, settings, font);
+
+  assert.equal(pdfDoc.getPageCount(), 1);
+});


### PR DESCRIPTION
## Summary
- add `npm test` script using Node's built-in test runner
- cover `drawTicketPage` in `pdfGenerator` with a simple unit test
- document how to run the tests in `README`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bd87037a0832297ebe42879fc440d