### PR TITLE
feat: integrate corporate font globally

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
   </head>
-  <body>
+  <body class="font-sans">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,7 +55,7 @@ function App() {
   const isThankYouPage = location.pathname.includes('/thank-you');
 
   return (
-    <div className="min-h-screen bg-white dark:bg-zinc-900 text-zinc-900 dark:text-white">
+    <div className="min-h-screen font-sans bg-white dark:bg-zinc-900 text-zinc-900 dark:text-white">
       {!isThankYouPage && <Header />}
       <main className={!isThankYouPage ? "pt-11" : ""}>
         <Routes>

--- a/src/components/admin/TicketPreview.jsx
+++ b/src/components/admin/TicketPreview.jsx
@@ -95,7 +95,7 @@ const TicketPreview = ({
   };
 
   return (
-    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-4">
+    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-4 font-sans">
       {/* Preview Controls */}
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,19 @@
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://fonts.gstatic.com/s/inter/v12/UcCO3FwrCvFzy5MdJNqvk2rN0g.woff2') format('woff2');
+}
+
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url('https://fonts.gstatic.com/s/inter/v12/UcCO3FwrCvFzy5MdJNqvk2rN7k.woff2') format('woff2');
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -9,7 +25,7 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   min-width: 320px;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+import defaultTheme from 'tailwindcss/defaultTheme';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
@@ -7,6 +9,9 @@ export default {
   darkMode: 'class',
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['Inter', ...defaultTheme.fontFamily.sans],
+      },
       maxWidth: {
         'container': '960px',
       },


### PR DESCRIPTION
## Summary
- add Inter font via `@font-face` and set as default font
- extend Tailwind theme with Inter and apply `font-sans` across app
- ensure TicketPreview and main layout use corporate font

## Testing
- `npm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689c57c38c08832293f7bfef7ae323ff