### PR TITLE
Fix ticket relation names in order queries

### DIFF
--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -356,7 +356,7 @@ const AdminPage = () => {
           *,
           order_items:order_items(
             *,
-            ticket:tickets!fk_order_items_ticket_id(
+            ticket:tickets!order_items_ticket_id_fkey(
               *,
               event:events(id, title, event_date, note)
             )
@@ -405,7 +405,7 @@ const AdminPage = () => {
         .select(`
           total_price,
           order_items:order_items(
-            ticket:tickets!fk_order_items_ticket_id(
+            ticket:tickets!order_items_ticket_id_fkey(
               event:events(category, note)
             )
           )

--- a/src/services/ticketService.js
+++ b/src/services/ticketService.js
@@ -491,7 +491,7 @@ export const getOrderDetails = async (orderId) => {
         *,
         order_items:order_items(
           *,
-          ticket:tickets!fk_order_items_ticket_id(
+          ticket:tickets!order_items_ticket_id_fkey(
             *,
             event:events(id, title, event_date, location, note),
             zone:zones(id, name, category:seat_categories(*)),
@@ -521,7 +521,7 @@ export const getAllOrders = async () => {
         order_items:order_items(
           id,
           unit_price,
-          ticket:tickets!fk_order_items_ticket_id(
+          ticket:tickets!order_items_ticket_id_fkey(
             id,
             status,
             event:events(title, event_date, note)


### PR DESCRIPTION
## Summary
- fix Supabase relation name for tickets when fetching order details
- correct admin dashboard queries to use proper ticket relations

## Testing
- `npm test` *(fails: fetch failed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c724e10988322b2aa1c08877ef4e6