### PR TITLE
fix: correct ticket join relation

### DIFF
--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -356,7 +356,7 @@ const AdminPage = () => {
           *,
           order_items:order_items(
             *,
-            ticket:tickets!order_items_ticket_id_fkey(
+            ticket:tickets!fk_order_items_ticket_id(
               *,
               event:events(id, title, event_date, note)
             )
@@ -405,7 +405,7 @@ const AdminPage = () => {
         .select(`
           total_price,
           order_items:order_items(
-            ticket:tickets!order_items_ticket_id_fkey(
+            ticket:tickets!fk_order_items_ticket_id(
               event:events(category, note)
             )
           )

--- a/src/services/ticketService.js
+++ b/src/services/ticketService.js
@@ -491,7 +491,7 @@ export const getOrderDetails = async (orderId) => {
         *,
         order_items:order_items(
           *,
-          ticket:tickets!order_items_ticket_id_fkey(
+          ticket:tickets!fk_order_items_ticket_id(
             *,
             event:events(id, title, event_date, location, note),
             zone:zones(id, name, category:seat_categories(*)),
@@ -521,7 +521,7 @@ export const getAllOrders = async () => {
         order_items:order_items(
           id,
           unit_price,
-          ticket:tickets!order_items_ticket_id_fkey(
+          ticket:tickets!fk_order_items_ticket_id(
             id,
             status,
             event:events(title, event_date, note)


### PR DESCRIPTION
## Summary
- fix revenue breakdown join for tickets
- update other queries to use `fk_order_items_ticket_id`

## Testing
- `node --input-type=module <<'NODE'
import supabase from './src/lib/supabase.js';
const { data, error } = await supabase
  .from('orders')
  .select(`
    *,
    order_items:order_items(
      *,
      ticket:tickets!fk_order_items_ticket_id(
        *,
        event:events(id, title, event_date, note)
      )
    )
  `)
  .eq('status', 'paid')
  .order('created_at', { ascending: false })
  .limit(2);
console.log('error', error);
console.log('records', data?.length);
NODE`
- `node --input-type=module <<'NODE'
import supabase from './src/lib/supabase.js';
const { data, error } = await supabase
  .from('orders')
  .select(`
    total_price,
    order_items:order_items(
      ticket:tickets!fk_order_items_ticket_id(
        event:events(category, note)
      )
    )
  `)
  .eq('status', 'paid')
  .limit(1);
console.log('error', error);
console.log('records', data?.length);
NODE`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c776dc0f4832289338218f3628162