### PR TITLE
feat: configure sentry with throttling

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@questlabs/react-sdk": "^2.2.4",
     "@supabase/supabase-js": "^2.39.0",
+    "@sentry/react": "^7.114.0",
     "react": "^18.3.1",
     "react-router-dom": "^7.1.0",
     "react-dom": "^18.3.1",

--- a/src/lib/sentry.js
+++ b/src/lib/sentry.js
@@ -1,0 +1,36 @@
+const EVENT_THROTTLE_MS = 1000;
+let lastEventTime = 0;
+
+export async function initSentry() {
+  if (import.meta.env.MODE === 'development') {
+    return;
+  }
+
+  const dsn = import.meta.env.VITE_SENTRY_DSN;
+  if (!dsn) {
+    return;
+  }
+
+  let Sentry;
+  try {
+    Sentry = await import('@sentry/react');
+  } catch (e) {
+    console.warn('Sentry SDK not available', e);
+    return;
+  }
+
+  Sentry.init({
+    dsn,
+    tracesSampleRate: 0.1,
+    maxBreadcrumbs: 50,
+    environment: import.meta.env.MODE,
+    beforeSend(event) {
+      const now = Date.now();
+      if (now - lastEventTime < EVENT_THROTTLE_MS) {
+        return null;
+      }
+      lastEventTime = now;
+      return event;
+    },
+  });
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,10 @@ import { HashRouter } from 'react-router-dom';
 import App from './App.jsx';
 import './index.css';
 
+import { initSentry } from './lib/sentry.js';
+
+initSentry();
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <HashRouter>


### PR DESCRIPTION
## Summary
- add @sentry/react dependency
- initialize Sentry with sample rate, breadcrumb limit, and throttle to reduce 429s
- disable Sentry during development

## Testing
- `npm run lint`
- `npm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689c814211448322b4ef984e212c89e9