### PR TITLE
feat: unify ticket terms generation

### DIFF
--- a/src/components/admin/TicketPreview.jsx
+++ b/src/components/admin/TicketPreview.jsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../../common/SafeIcon';
 import { formatDateTime } from '../../utils/formatDateTime';
+import { buildTermsText } from '../../utils/ticketUtils';
 import QRCode from 'qrcode';
 
 const { FiDownload, FiRefreshCw } = FiIcons;
@@ -77,11 +78,7 @@ const TicketPreview = ({
   }
   if (showPriceFinal && price) gridItems.push(['PRICE', price]);
 
-  const termsText = showTermsFinal
-    ? [event.note, ticketContent.customInstructions, ticketContent.termsAndConditions, o.terms]
-        .filter(Boolean)
-        .join(' ')
-    : '';
+  const termsText = showTermsFinal ? buildTermsText(o, settings) : '';
 
   const qrString = qrCode.value || qrValue || ticketId || 'Ticket';
   const qrBlockSize = 164;

--- a/src/utils/pdfGenerator.js
+++ b/src/utils/pdfGenerator.js
@@ -2,6 +2,7 @@ import { PDFDocument, rgb } from 'pdf-lib';
 import fontkit from '@pdf-lib/fontkit';
 import QRCode from 'qrcode';
 import { formatDateTime } from './formatDateTime.js';
+import { buildTermsText } from './ticketUtils.js';
 
 function sanitizeValue(value) {
   return value === undefined || value === null ? '' : String(value).replace(/\s+/g, ' ').trim();
@@ -73,7 +74,8 @@ async function drawTicketPage(pdfDoc, order, seat, settings = {}, font) {
   const data = sanitizeTicket(order, seat);
   const { colorScheme = {}, design = {}, qrCode = {}, ticketContent = {}, companyInfo = {} } = settings;
 
-  const showTerms = ticketContent.showTerms && (ticketContent.termsAndConditions || data.terms);
+  const termsText = buildTermsText(order, settings);
+  const showTerms = ticketContent.showTerms !== false && termsText;
 
   const pageWidth = 560;
   const pageHeight = showTerms ? 860 : 700;
@@ -289,8 +291,7 @@ async function drawTicketPage(pdfDoc, order, seat, settings = {}, font) {
   }
 
   // terms section
-  const termsText = showTerms && (ticketContent.termsAndConditions || data.terms);
-  if (termsText) {
+  if (showTerms) {
     page.drawLine({
       start: { x: cardX + padX, y: cursorY },
       end: { x: cardX + cardWidth - padX, y: cursorY },

--- a/src/utils/ticketUtils.js
+++ b/src/utils/ticketUtils.js
@@ -1,0 +1,12 @@
+export function buildTermsText(order = {}, settings = {}) {
+  const eventNote = order?.event?.note;
+  const ticketContent = settings.ticketContent || {};
+  return [
+    eventNote,
+    ticketContent.customInstructions,
+    ticketContent.termsAndConditions,
+    order?.terms
+  ]
+    .filter(Boolean)
+    .join(' ');
+}


### PR DESCRIPTION
## Summary
- add buildTermsText helper for assembling ticket terms
- reuse helper in TicketPreview and PDF generator for consistent terms display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c9e3ff0f883229bd764c21e7f5f75