### PR TITLE
Handle ticket template load failures

### DIFF
--- a/src/utils/applyTicketTemplate.js
+++ b/src/utils/applyTicketTemplate.js
@@ -13,12 +13,20 @@ function getValue(obj, path) {
 
 async function loadTemplate() {
   const url = new URL('../templates/ticket.html', import.meta.url);
-  if (typeof window !== 'undefined' && window.fetch) {
-    const res = await fetch(url);
-    return res.text();
+  try {
+    if (typeof window !== 'undefined' && window.fetch) {
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error(`Failed to fetch template: ${res.status} ${res.statusText}`);
+      }
+      return res.text();
+    }
+    const { readFile } = await import('node:fs/promises');
+    return await readFile(url, 'utf-8');
+  } catch (err) {
+    console.error('Error loading ticket template:', err);
+    return '<div>Ticket template unavailable</div>';
   }
-  const { readFile } = await import('node:fs/promises');
-  return readFile(url, 'utf-8');
 }
 
 export async function applyTicketTemplate(data = {}) {

--- a/src/utils/applyTicketTemplate.test.js
+++ b/src/utils/applyTicketTemplate.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { applyTicketTemplate } from './applyTicketTemplate.js';
+import { rename } from 'node:fs/promises';
 
 test('applyTicketTemplate inserts event and seat info', async () => {
   const order = {
@@ -17,4 +18,16 @@ test('applyTicketTemplate inserts event and seat info', async () => {
   assert.ok(html.includes('SEC'));
   assert.ok(html.includes('ROW'));
   assert.ok(html.includes('10'));
+});
+
+test('applyTicketTemplate returns fallback HTML when template is missing', async () => {
+  const original = new URL('../templates/ticket.html', import.meta.url);
+  const backup = new URL('../templates/ticket.html.bak', import.meta.url);
+  await rename(original, backup);
+  try {
+    const html = await applyTicketTemplate();
+    assert.ok(html.includes('Ticket template unavailable'));
+  } finally {
+    await rename(backup, original);
+  }
 });


### PR DESCRIPTION
## Summary
- add error handling and fallback HTML to `loadTemplate`
- test template load failure path

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca66f3e1c832281450c6c4954ee58