### PR TITLE
test: add service and PDF generator tests

### DIFF
--- a/src/services/eventService.test.js
+++ b/src/services/eventService.test.js
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+test('fetchEventById returns event with prices', async (t) => {
+  const mockSupabase = {
+    from(table) {
+      if (table === 'events') {
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  single: async () => ({ data: { id: 1, title: 'Concert', venue: {} }, error: null })
+                };
+              }
+            };
+          }
+        };
+      }
+      if (table === 'event_prices') {
+        return {
+          select() {
+            return {
+              eq() {
+                return Promise.resolve({ data: [{ price: 50 }, { price: 30 }], error: null });
+              }
+            };
+          }
+        };
+      }
+      return {};
+    }
+  };
+
+  global.__mockSupabase = mockSupabase;
+  global.__mockTicketService = { createEventTickets: async () => ({}) };
+  const code = await fs.readFile(new URL('./eventService.js', import.meta.url), 'utf8');
+  const patched = code
+    .replace("import supabase from '../lib/supabase';", 'const supabase = global.__mockSupabase;')
+    .replace("import {createEventTickets} from './ticketService';", 'const {createEventTickets} = global.__mockTicketService;');
+  const { fetchEventById } = await import(`data:text/javascript;base64,${Buffer.from(patched).toString('base64')}`);
+
+  const result = await fetchEventById(1);
+  assert.equal(result.id, 1);
+  assert.equal(result.price, 30);
+  assert.equal(result.prices.length, 2);
+  delete global.__mockSupabase;
+  delete global.__mockTicketService;
+});

--- a/src/services/ticketService.test.js
+++ b/src/services/ticketService.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+test('createEventTickets calls RPC and returns data', async (t) => {
+  const rpcCalls = [];
+  const mockSupabase = {
+    rpc: async (fn, params) => {
+      rpcCalls.push({ fn, params });
+      return { data: { success: true }, error: null };
+    }
+  };
+
+  global.__mockSupabase = mockSupabase;
+  const code = await fs.readFile(new URL('./ticketService.js', import.meta.url), 'utf8');
+  const patched = code.replace("import supabase from '../lib/supabase';", 'const supabase = global.__mockSupabase;');
+  const { createEventTickets } = await import(`data:text/javascript;base64,${Buffer.from(patched).toString('base64')}`);
+
+  const result = await createEventTickets(42);
+  assert.deepEqual(result, { success: true });
+  assert.equal(rpcCalls.length, 1);
+  assert.equal(rpcCalls[0].fn, 'create_event_tickets');
+  assert.deepEqual(rpcCalls[0].params, { p_event_id: 42 });
+  delete global.__mockSupabase;
+});

--- a/src/utils/pdfGenerator.test.js
+++ b/src/utils/pdfGenerator.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+// Minimal DOM stubs
+global.document = {
+  createElement: (tag) => ({
+    tagName: tag,
+    style: {},
+    innerHTML: '',
+    firstElementChild: {},
+    click: () => {},
+  }),
+  body: {
+    appendChild: () => {},
+    removeChild: () => {},
+  },
+};
+
+global.URL.createObjectURL = () => 'blob:mock';
+global.URL.revokeObjectURL = () => {};
+global.fetch = async () => ({ arrayBuffer: async () => new ArrayBuffer(0) });
+
+test('downloadTicketsPDF creates a page for each seat', async (t) => {
+  const addPageCalls = [];
+  const pdfDocMock = {
+    addPage: (size) => { addPageCalls.push(size); return { drawImage: () => {} }; },
+    embedPng: async () => ({ width: 100, height: 50 }),
+    save: async () => new Uint8Array(),
+  };
+  let applyCalls = 0;
+  const applyMock = async () => { applyCalls++; return '<div></div>'; };
+  let canvasCalls = 0;
+  const html2canvasMock = async () => {
+    canvasCalls++;
+    return { toDataURL: () => 'data:image/png;base64,AAAA' };
+  };
+
+  global.__mockPDFLib = { PDFDocument: { create: async () => pdfDocMock } };
+  global.__mockHtml2Canvas = html2canvasMock;
+  global.__mockApply = { applyTicketTemplate: applyMock };
+  const code = await fs.readFile(new URL('./pdfGenerator.js', import.meta.url), 'utf8');
+  const patched = code
+    .replace("import { PDFDocument } from 'pdf-lib';", 'const { PDFDocument } = global.__mockPDFLib;')
+    .replace("import html2canvas from 'html2canvas';", 'const html2canvas = global.__mockHtml2Canvas;')
+    .replace("import { applyTicketTemplate } from './applyTicketTemplate.js';", 'const { applyTicketTemplate } = global.__mockApply;');
+  const { downloadTicketsPDF } = await import(`data:text/javascript;base64,${Buffer.from(patched).toString('base64')}`);
+
+  const order = { seats: [{ id: 1 }, { id: 2 }], event: {} };
+  await downloadTicketsPDF(order, 'test.pdf', { design: {} });
+
+  assert.equal(applyCalls, 2);
+  assert.equal(canvasCalls, 2);
+  assert.equal(addPageCalls.length, 2);
+  delete global.__mockPDFLib;
+  delete global.__mockHtml2Canvas;
+  delete global.__mockApply;
+});


### PR DESCRIPTION
## Summary
- add unit test for PDF ticket generation
- cover event and ticket services with mocked Supabase interactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ca8fda05483229e52bb932adcc61a