### PR TITLE
Avoid Sentry 429s in development

### DIFF
--- a/src/lib/sentry.js
+++ b/src/lib/sentry.js
@@ -1,8 +1,19 @@
 const EVENT_THROTTLE_MS = 1000;
 let lastEventTime = 0;
 
+const MAX_BACKOFF_MS = 60000;
+let backoffMs = 0;
+let nextAttempt = 0;
+
 export async function initSentry() {
-  if (import.meta.env.MODE === 'development') {
+  const isLocalhost =
+    typeof window !== 'undefined' &&
+    ['localhost', '127.0.0.1'].includes(window.location.hostname);
+
+  if (import.meta.env.DEV || isLocalhost || Date.now() < nextAttempt) {
+    if (Date.now() < nextAttempt) {
+      console.warn('Sentry initialization skipped due to rate limiting');
+    }
     return;
   }
 
@@ -12,18 +23,40 @@ export async function initSentry() {
   }
 
   let Sentry;
+  let makeFetchTransport;
   try {
     Sentry = await import('@sentry/react');
+    ({ makeFetchTransport } = await import('@sentry/browser'));
   } catch (e) {
     console.warn('Sentry SDK not available', e);
     return;
   }
+
+  const baseTransport = makeFetchTransport({ dsn });
+  const transport = {
+    send: async (request) => {
+      if (Date.now() < nextAttempt) {
+        console.warn('Sentry event skipped due to rate limiting');
+        return { statusCode: 429 };
+      }
+      const response = await baseTransport.send(request);
+      if (response && response.statusCode === 429) {
+        backoffMs = backoffMs ? Math.min(backoffMs * 2, MAX_BACKOFF_MS) : 1000;
+        nextAttempt = Date.now() + backoffMs;
+        console.warn(`Sentry rate limited. Backing off for ${backoffMs}ms`);
+      } else {
+        backoffMs = 0;
+      }
+      return response;
+    },
+  };
 
   Sentry.init({
     dsn,
     tracesSampleRate: 0.1,
     maxBreadcrumbs: 50,
     environment: import.meta.env.MODE,
+    transport,
     beforeSend(event) {
       const now = Date.now();
       if (now - lastEventTime < EVENT_THROTTLE_MS) {


### PR DESCRIPTION
## Summary
- Skip Sentry initialization on localhost or during development
- Add transport-level exponential backoff to stop sending events after 429 responses

## Testing
- `npm test`
- `npm run lint`
- `timeout 5 npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689cb076f798832285f67c61b8281a91