### PR TITLE
Fix order item relation in preview refresh

### DIFF
--- a/database-setup.sql
+++ b/database-setup.sql
@@ -9,10 +9,14 @@ CREATE TABLE tickets (
   seat_id UUID REFERENCES single_seats(id) ON DELETE CASCADE,
   status TEXT NOT NULL DEFAULT 'free' CHECK (status IN ('free','held','sold')),
   hold_expires_at TIMESTAMPTZ,
-  order_item_id UUID REFERENCES order_items(id) ON DELETE SET NULL,
+  order_item_id UUID,
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW(),
-  
+
+  CONSTRAINT tickets_order_item_id_fkey
+    FOREIGN KEY (order_item_id)
+    REFERENCES order_items(id)
+    ON DELETE SET NULL,
   -- Constraint: ticket должен быть либо для zone, либо для seat
   CONSTRAINT ticket_zone_or_seat CHECK (
     (zone_id IS NOT NULL AND seat_id IS NULL) OR 

--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -530,7 +530,7 @@ const TicketTemplateSettings = () => {
           event:events(title, event_date, location, note),
           zone:zones(name),
           seat:single_seats(row_number, seat_number, section),
-          order_item:order_items(
+          order_item:order_items!tickets_order_item_id_fkey(
             unit_price,
             order:orders(id, user_id, total_price)
           )


### PR DESCRIPTION
## Summary
- correctly join order_items in preview refresh using tickets_order_item_id_fkey
- explicitly name tickets → order_items foreign key in schema

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb6aa6fb88322ab829bb9b9bd1afe