### PR TITLE
feat: redesign ticket template with Tailwind slots

### DIFF
--- a/src/templates/ticket.html
+++ b/src/templates/ticket.html
@@ -1,28 +1,39 @@
 <div data-canvas-width="560" class="ticket w-[560px] bg-white text-gray-900 font-sans border rounded-lg overflow-hidden shadow-md">
-  <div class="flex items-center justify-between px-6 py-4 bg-gray-100 border-b">
-    <h1 class="text-xl font-bold" data-slot="event.title"></h1>
-    <span class="text-sm" data-slot="settings.companyInfo.brand"></span>
+  <div class="relative h-40 w-full">
+    <img data-slot="heroImage" alt="" class="absolute inset-0 w-full h-full object-cover" />
+    <div class="absolute inset-0 bg-gradient-to-b from-transparent via-black/30 to-black/70"></div>
+    <span data-slot="brand" class="absolute top-4 left-4 px-2 py-1 bg-black/70 text-white text-xs font-semibold rounded"></span>
   </div>
-  <div class="px-6 py-4">
-    <div class="text-base" data-slot="event.location"></div>
-    <div class="text-sm text-gray-600" data-slot="event.event_date"></div>
-  </div>
-  <div class="px-6 py-4 grid grid-cols-4 gap-4 text-center border-t">
-    <div>
-      <div class="text-xs text-gray-500">SECTION</div>
-      <div class="text-lg font-semibold" data-slot="seat.section"></div>
+  <div class="p-6 space-y-2">
+    <h1 class="text-2xl font-bold" data-slot="artist"></h1>
+    <div class="text-sm text-gray-600" data-slot="dateTime"></div>
+    <div class="text-sm" data-slot="venue"></div>
+    <div class="text-sm text-gray-500" data-slot="address"></div>
+    <div class="mt-6 grid grid-cols-4 gap-4 text-center">
+      <div>
+        <div class="text-xs text-gray-500">SECTION</div>
+        <div class="text-lg font-semibold" data-slot="section"></div>
+      </div>
+      <div>
+        <div class="text-xs text-gray-500">ROW</div>
+        <div class="text-lg font-semibold" data-slot="row"></div>
+      </div>
+      <div>
+        <div class="text-xs text-gray-500">SEAT</div>
+        <div class="text-lg font-semibold" data-slot="seat"></div>
+      </div>
+      <div>
+        <div class="text-xs text-gray-500">PRICE</div>
+        <div class="text-lg font-semibold" data-slot="price"></div>
+      </div>
     </div>
-    <div>
-      <div class="text-xs text-gray-500">ROW</div>
-      <div class="text-lg font-semibold" data-slot="seat.row_number"></div>
+    <div class="mt-6 flex items-center justify-between">
+      <div class="flex flex-col items-center">
+        <div class="w-32 h-32 bg-gray-200 flex items-center justify-center" data-slot="qr"></div>
+        <div class="mt-2 text-xs text-gray-500" data-slot="qrValue"></div>
+        <div class="text-xs text-gray-500" data-slot="ticketId"></div>
+      </div>
     </div>
-    <div>
-      <div class="text-xs text-gray-500">SEAT</div>
-      <div class="text-lg font-semibold" data-slot="seat.seat_number"></div>
-    </div>
-    <div>
-      <div class="text-xs text-gray-500">PRICE</div>
-      <div class="text-lg font-semibold" data-slot="seat.price"></div>
-    </div>
+    <div class="mt-6 text-[10px] text-gray-500" data-slot="terms"></div>
   </div>
 </div>

--- a/src/utils/applyTicketTemplate.test.js
+++ b/src/utils/applyTicketTemplate.test.js
@@ -3,24 +3,19 @@ import assert from 'node:assert/strict';
 import { applyTicketTemplate } from './applyTicketTemplate.js';
 import { rename } from 'node:fs/promises';
 
-test('applyTicketTemplate inserts event and seat info', async () => {
-  const order = {
-    event: {
-      title: 'Show',
-      event_date: '2025-08-13T20:25:00Z',
-      location: 'Venue',
-    },
-    orderNumber: '123',
-    price: '$50',
-  };
-  const seat = {
+test('applyTicketTemplate inserts ticket details', async () => {
+  const html = await applyTicketTemplate({
+    brand: 'MyBrand',
+    artist: 'Show',
+    dateTime: '2025-08-13T20:25:00Z',
+    venue: 'Venue',
+    address: '123 Street',
     section: 'SEC',
-    row_number: 'ROW',
-    seat_number: '10',
+    row: 'ROW',
+    seat: '10',
     price: '$50',
-  };
-  const settings = { companyInfo: { brand: 'MyBrand' } };
-  const html = await applyTicketTemplate({ order, seat, settings });
+  });
+
   assert.ok(html.includes('Show'));
   assert.ok(html.includes('MyBrand'));
   assert.ok(html.includes('SECTION'));


### PR DESCRIPTION
## Summary
- replace ticket template with Tailwind-based layout including hero image, brand chip, ticket details, and QR placeholder
- update applyTicketTemplate test for new slot names

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb9aef4848322bff852efc5436485