### PR TITLE
Render TicketTemplate using server markup

### DIFF
--- a/src/components/ticket/TicketTemplateNode.js
+++ b/src/components/ticket/TicketTemplateNode.js
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import QRCode from 'qrcode';
 
-const TicketTemplate = (props) => {
+const TicketTemplate = (props = {}) => {
+  const data = props.data || props;
   const {
     heroImage,
     brand,
@@ -26,7 +27,7 @@ const TicketTemplate = (props) => {
     showPrice = true,
     showTerms = true,
     darkHeader = false,
-  } = props;
+  } = data;
 
   const [qr, setQr] = useState(qrImage);
 

--- a/src/utils/applyTicketTemplate.js
+++ b/src/utils/applyTicketTemplate.js
@@ -1,7 +1,41 @@
 import React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import { renderToStaticMarkup } from 'react-dom/server';
 import QRCode from 'qrcode';
 import TicketTemplate from '../components/ticket/TicketTemplateNode.js';
+
+export function sanitizeTicket(data = {}) {
+  const stringFields = [
+    'heroImage',
+    'brand',
+    'artist',
+    'date',
+    'time',
+    'venue',
+    'address',
+    'section',
+    'row',
+    'seat',
+    'gate',
+    'price',
+    'currency',
+    'qrImage',
+    'qrValue',
+    'ticketId',
+    'terms',
+  ];
+  const result = { ...data };
+  for (const key of stringFields) {
+    const val = result[key];
+    result[key] = val === undefined || val === null ? undefined : String(val);
+  }
+  result.rounded = result.rounded ?? true;
+  result.shadow = result.shadow ?? true;
+  result.showQr = result.showQr ?? true;
+  result.showPrice = result.showPrice ?? true;
+  result.showTerms = result.showTerms ?? true;
+  result.darkHeader = result.darkHeader ?? false;
+  return result;
+}
 
 export async function applyTicketTemplate(data = {}) {
   const { order = {}, seat = {}, settings = {}, ...rest } = data;
@@ -22,7 +56,7 @@ export async function applyTicketTemplate(data = {}) {
     }
   }
 
-  const props = {
+  const props = sanitizeTicket({
     heroImage: rest.heroUrl || settings.design?.heroUrl || event.image,
     brand: rest.brand || company.name,
     artist: rest.artist || event.title,
@@ -47,7 +81,7 @@ export async function applyTicketTemplate(data = {}) {
     showPrice: rest.showPrice ?? true,
     showTerms: rest.showTerms ?? true,
     darkHeader: rest.darkHeader ?? false,
-  };
+  });
 
   if (props.showQr && props.qrValue) {
     try {
@@ -57,8 +91,8 @@ export async function applyTicketTemplate(data = {}) {
     }
   }
 
-  return ReactDOMServer.renderToStaticMarkup(
-    React.createElement(TicketTemplate, props),
+  return renderToStaticMarkup(
+    React.createElement(TicketTemplate, { data: props }),
   );
 }
 

--- a/src/utils/applyTicketTemplate.test.js
+++ b/src/utils/applyTicketTemplate.test.js
@@ -2,27 +2,20 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { applyTicketTemplate } from './applyTicketTemplate.js';
 
-test('applyTicketTemplate renders ticket details', async () => {
+test('applyTicketTemplate renders ticket template with provided data', async () => {
   const html = await applyTicketTemplate({
     brand: 'MyBrand',
     artist: 'Show',
-    date: '2025-08-13',
-    time: '20:25',
-    venue: 'Venue',
-    address: '123 Street',
-    section: 'SEC',
-    row: 'ROW',
-    seat: '10',
-    gate: 'G1',
-    price: '50',
-    currency: '$',
+    seat: 10,
+    price: 50,
     qrValue: 'QRDATA',
     ticketId: 'ID123',
     terms: 'No refunds',
   });
+  assert.ok(html.includes('ticket w-[560px]'));
   assert.ok(html.includes('MyBrand'));
   assert.ok(html.includes('Show'));
-  assert.ok(html.includes('G1'));
+  assert.ok(html.includes('10'));
   assert.ok(html.includes('50'));
   assert.ok(html.includes('No refunds'));
 });


### PR DESCRIPTION
## Summary
- render TicketTemplate to HTML with renderToStaticMarkup
- sanitize ticket data before rendering
- update test to confirm HTML output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cbf11e45c83228d693b5ce38c3b0c