### PR TITLE
Handle new ticket template fields and options

### DIFF
--- a/src/utils/applyTicketTemplate.js
+++ b/src/utils/applyTicketTemplate.js
@@ -3,9 +3,31 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import QRCode from 'qrcode';
 import TicketTemplate from '../components/ticket/TicketTemplateNode.js';
 
+const DEFAULT_HERO = 'https://via.placeholder.com/560x160.png?text=Ticket';
+
+function validateImageUrl(url) {
+  if (!url) return undefined;
+  if (String(url).startsWith('data:image')) return String(url);
+  try {
+    const { protocol } = new URL(url);
+    if (protocol === 'http:' || protocol === 'https:') return url;
+  } catch {
+    // ignore invalid URLs
+  }
+  return undefined;
+}
+
+function validateColor(color) {
+  if (typeof color !== 'string') return undefined;
+  const value = color.trim();
+  return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(value) ? value : undefined;
+}
+
 export function sanitizeTicket(data = {}) {
   const stringFields = [
+    'ticketType',
     'heroImage',
+    'heroUrl',
     'brand',
     'artist',
     'date',
@@ -16,11 +38,12 @@ export function sanitizeTicket(data = {}) {
     'row',
     'seat',
     'gate',
-    'price',
     'currency',
     'qrImage',
+    'qrValue',
     'ticketId',
     'terms',
+    'accent',
   ];
   const result = { ...data };
   for (const key of stringFields) {
@@ -30,11 +53,24 @@ export function sanitizeTicket(data = {}) {
   return result;
 }
 
+function coerceBoolean(override, setting, fallback) {
+  return override !== undefined
+    ? Boolean(override)
+    : setting !== undefined
+      ? Boolean(setting)
+      : fallback;
+}
+
+function coerceNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : undefined;
+}
+
 export async function applyTicketTemplate(data = {}) {
   const { order = {}, seat = {}, settings = {}, ...rest } = data;
   const event = order.event || {};
   const company = order.company || {};
-  const seatInfo = Object.keys(seat).length ? seat : (order.seat || {});
+  const seatInfo = Object.keys(seat).length ? seat : order.seat || {};
 
   let date = rest.date;
   let time = rest.time;
@@ -49,35 +85,68 @@ export async function applyTicketTemplate(data = {}) {
     }
   }
 
+  const reserved = Boolean(
+    seatInfo.section || seatInfo.row_number || seatInfo.seat_number,
+  );
+
+  const heroUrl =
+    validateImageUrl(rest.heroUrl) ||
+    validateImageUrl(settings.design?.heroUrl) ||
+    validateImageUrl(event.image) ||
+    DEFAULT_HERO;
+
+  const priceSource = rest.price ?? seatInfo.price ?? order.price;
+  const priceVal = priceSource !== undefined ? coerceNumber(priceSource) : undefined;
+
+  const roundedVal = coerceNumber(rest.rounded ?? settings.design?.rounded);
+
   const ticketData = sanitizeTicket({
-    heroImage: rest.heroUrl || settings.design?.heroUrl || event.image,
+    ticketType: rest.ticketType || (reserved ? 'reserved' : 'ga'),
+    heroImage: heroUrl,
+    heroUrl,
     brand: rest.brand || company.name,
     artist: rest.artist || event.title,
     date,
     time,
     venue: rest.venue || event.location,
     address: rest.address || event.address,
-    section: rest.section || seatInfo.section,
-    row: rest.row || seatInfo.row_number,
-    seat: rest.seat || seatInfo.seat_number,
-    gate: rest.gate || seatInfo.gate,
-    price: rest.price || seatInfo.price || order.price,
+    section: reserved ? rest.section || seatInfo.section : undefined,
+    row: reserved ? rest.row || seatInfo.row_number : undefined,
+    seat: reserved ? rest.seat || seatInfo.seat_number : undefined,
+    gate: reserved ? rest.gate || seatInfo.gate : undefined,
+    price: priceVal,
     currency: rest.currency || order.currency,
     ticketId: rest.ticketId || seatInfo.id || order.orderNumber,
     terms: rest.terms || settings.terms,
   });
 
-  const options = {
-    accent: rest.accent || settings.design?.accent,
-    darkHeader: rest.darkHeader ?? settings.design?.darkHeader ?? false,
-    showPrice: rest.showPrice ?? true,
-    showQr: rest.showQr ?? true,
-    showTerms: rest.showTerms ?? true,
-    radius:
-      rest.radius === undefined ? settings.design?.rounded : rest.radius,
-    shadow: rest.shadow ?? true,
+  const options = sanitizeTicket({
+    accent: validateColor(rest.accent ?? settings.design?.accent),
+    darkHeader: coerceBoolean(
+      rest.darkHeader,
+      settings.design?.darkHeader,
+      false,
+    ),
+    showPrice: coerceBoolean(
+      rest.showPrice,
+      settings.ticketContent?.showPrice,
+      true,
+    ),
+    showQr: coerceBoolean(
+      rest.showQr,
+      settings.design?.showQr ?? settings.design?.showQRCode,
+      true,
+    ),
+    showTerms: coerceBoolean(
+      rest.showTerms,
+      settings.ticketContent?.showTerms,
+      true,
+    ),
+    shadow: coerceBoolean(rest.shadow, settings.design?.shadow, true),
+    rounded: roundedVal,
+    radius: roundedVal,
     qrValue: rest.qrValue || order.orderNumber || seatInfo.id,
-  };
+  });
 
   if (options.showQr && options.qrValue) {
     try {


### PR DESCRIPTION
## Summary
- Sanitize additional ticket and option fields like ticketType, qrValue, heroUrl and accent
- Support boolean and numeric overrides for new template options
- Populate GA vs reserved ticket data with validated hero images and accent colors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cc569ff28832288b5e124354bfddb