### PR TITLE
Propagate ticket template options

### DIFF
--- a/src/components/admin/TicketLayoutSettings.jsx
+++ b/src/components/admin/TicketLayoutSettings.jsx
@@ -108,7 +108,7 @@ const TicketLayoutSettings = ({
         settings={settings}
         accent={settings.design.accent}
         darkHeader={settings.design.darkHeader}
-        radius={settings.design.rounded}
+        rounded={settings.design.rounded}
         shadow={settings.design.shadow}
         showPrice={settings.ticketContent.showPrice}
         showQr={settings.design.showQRCode}
@@ -116,7 +116,7 @@ const TicketLayoutSettings = ({
         onDownload={onDownloadPreview}
         onRefresh={onRefreshPreview}
         ticketData={ticketData}
-        qrValue={ticketData?.ticketNumber}
+        qrValue={ticketData?.qrValue}
       />
     </div>
   );

--- a/src/components/admin/TicketPreview.jsx
+++ b/src/components/admin/TicketPreview.jsx
@@ -3,67 +3,59 @@ import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../../common/SafeIcon';
 import TicketTemplate from '../ticket/TicketTemplate.jsx';
+import { buildTermsText } from '../../utils/ticketUtils.js';
 
 const { FiDownload, FiRefreshCw } = FiIcons;
 
 const TicketPreview = ({
-  order,
-  seat,
+  ticketData,
   onDownload,
   onRefresh,
-  heroUrl,
   accent,
   darkHeader,
   showPrice = true,
   showQr = true,
   showTerms = true,
-  radius,
+  rounded,
   shadow,
   qrValue,
   settings = {},
 }) => {
-  const sampleOrder = {
-    event: {
-      title: 'Концерт группы "Пример"',
-      date: '2024-12-15T20:00:00',
-      location: 'Концертный зал "Олимпийский"',
-      note: 'Пожалуйста, приходите за 30 минут до начала.'
-    },
-    orderNumber: 'TW-123456',
-    price: '2500 ₽',
-    company: { name: 'TicketWayz' }
-  };
-  const sampleSeat = {
-    id: 'SAMPLE-SEAT',
+  const sampleTicket = {
+    brand: 'TicketWayz',
+    artist: 'Концерт группы "Пример"',
+    date: '15.12.2024',
+    time: '20:00',
+    venue: 'Концертный зал "Олимпийский"',
+    address: 'Пожалуйста, приходите за 30 минут до начала.',
     section: 'Партер',
-    row_number: '5',
-    seat_number: '12',
-    price: '2500 ₽'
+    row: '5',
+    seat: '12',
+    price: '2500 ₽',
+    ticketId: 'TW-123456',
+    ticketType: 'seat',
+    qrValue: 'TW-123456',
   };
 
-  const o = order || sampleOrder;
-  const s = seat || sampleSeat;
-
-  const dateObj = o.event?.date ? new Date(o.event.date) : null;
-  const date = dateObj ? dateObj.toLocaleDateString() : undefined;
-  const time = dateObj ? dateObj.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : undefined;
+  const t = { ...sampleTicket, ...(ticketData || {}) };
 
   const ticketRef = useRef(null);
 
   const data = {
-    heroImage: heroUrl || settings.design?.heroUrl || o.event.image,
-    brand: o.company?.name,
-    artist: o.event?.title,
-    date,
-    time,
-    venue: o.event?.location,
-    address: o.event?.note,
-    section: s.section,
-    row: s.row_number,
-    seat: s.seat_number,
-    price: s.price || o.price,
-    ticketId: s.id || o.orderNumber,
-    terms: settings.terms,
+    heroImage: t.heroImage || settings.design?.heroUrl,
+    brand: t.brand,
+    artist: t.artist,
+    date: t.date,
+    time: t.time,
+    venue: t.venue,
+    address: t.address,
+    section: t.section,
+    row: t.row,
+    seat: t.seat,
+    price: t.price,
+    ticketId: t.ticketId,
+    ticketType: t.ticketType,
+    terms: buildTermsText({}, settings),
   };
 
   const options = {
@@ -72,9 +64,10 @@ const TicketPreview = ({
     showPrice,
     showQr,
     showTerms,
-    radius,
+    rounded,
+    radius: rounded,
     shadow,
-    qrValue,
+    qrValue: qrValue || t.qrValue || t.ticketId,
   };
 
   return (

--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -25,38 +25,6 @@ const TicketTemplateSettings = () => {
   const [lastSoldTicket, setLastSoldTicket] = useState(null);
   const [refreshingPreview, setRefreshingPreview] = useState(false);
 
-  // Формируем данные билета для предпросмотра на основе последнего проданного билета
-  const previewTicketData = useMemo(() => {
-    if (!lastSoldTicket) return null;
-    const eventDateRaw = lastSoldTicket.event?.event_date;
-    let eventDate = '';
-    let eventTime = '';
-    if (eventDateRaw) {
-      const { date, time } = formatDateTime(eventDateRaw);
-      eventDate = date;
-      eventTime = time;
-    }
-    return {
-      eventTitle: lastSoldTicket.event?.title || '',
-      eventDate,
-      eventTime,
-      eventLocation: lastSoldTicket.event?.location || '',
-      orderNumber: lastSoldTicket.order_item?.order?.id
-        ? `TW-${lastSoldTicket.order_item.order.id.substring(0, 6)}`
-        : '',
-      seatInfo: lastSoldTicket.seat
-        ? `${lastSoldTicket.seat.section} ряд ${lastSoldTicket.seat.row_number} место ${lastSoldTicket.seat.seat_number}`
-        : lastSoldTicket.zone
-          ? `Зона "${lastSoldTicket.zone.name}"`
-          : 'Общий вход',
-      price: lastSoldTicket.order_item?.unit_price
-        ? `€${parseFloat(lastSoldTicket.order_item.unit_price).toFixed(2)}`
-        : '',
-      ticketNumber: lastSoldTicket.id
-        ? `T-${lastSoldTicket.id.substring(0, 8)}`
-        : ''
-    };
-  }, [lastSoldTicket]);
 
   // Настройки шаблона билета
   const [templateSettings, setTemplateSettings] = useState({
@@ -107,6 +75,45 @@ const TicketTemplateSettings = () => {
       accent: '#f59e0b'
     }
   });
+
+  // Формируем данные билета для предпросмотра на основе последнего проданного билета
+  const previewTicketData = useMemo(() => {
+    if (!lastSoldTicket) return null;
+    const eventDateRaw = lastSoldTicket.event?.event_date;
+    let eventDate = '';
+    let eventTime = '';
+    if (eventDateRaw) {
+      const { date, time } = formatDateTime(eventDateRaw);
+      eventDate = date;
+      eventTime = time;
+    }
+    return {
+      brand: templateSettings.companyInfo?.brand || 'TicketWayz',
+      heroImage: templateSettings.design?.heroUrl || lastSoldTicket.event?.image || '',
+      artist: lastSoldTicket.event?.title || '',
+      date: eventDate,
+      time: eventTime,
+      venue: lastSoldTicket.event?.location || '',
+      address: lastSoldTicket.event?.note || '',
+      section: lastSoldTicket.seat?.section,
+      row: lastSoldTicket.seat?.row_number,
+      seat: lastSoldTicket.seat?.seat_number,
+      price: lastSoldTicket.order_item?.unit_price
+        ? `€${parseFloat(lastSoldTicket.order_item.unit_price).toFixed(2)}`
+        : '',
+      ticketId: lastSoldTicket.id
+        ? `T-${lastSoldTicket.id.substring(0, 8)}`
+        : '',
+      ticketType: lastSoldTicket.seat
+        ? 'seat'
+        : lastSoldTicket.zone
+          ? 'zone'
+          : 'general',
+      qrValue: lastSoldTicket.id
+        ? `T-${lastSoldTicket.id.substring(0, 8)}`
+        : '',
+    };
+  }, [lastSoldTicket, templateSettings]);
 
   // Настройки SMTP
   const [smtpSettings, setSmtpSettings] = useState({
@@ -569,6 +576,13 @@ const TicketTemplateSettings = () => {
       },
       seats: [
         {
+          id: lastSoldTicket.id
+            ? `T-${lastSoldTicket.id.substring(0, 8)}`
+            : undefined,
+          section: lastSoldTicket.seat?.section,
+          row_number: lastSoldTicket.seat?.row_number,
+          seat_number: lastSoldTicket.seat?.seat_number,
+          price: lastSoldTicket.order_item?.unit_price,
           label: lastSoldTicket.seat
             ? `${lastSoldTicket.seat.section} ряд ${lastSoldTicket.seat.row_number} место ${lastSoldTicket.seat.seat_number}`
             : lastSoldTicket.zone


### PR DESCRIPTION
## Summary
- add ticketType and qrValue to preview data
- pass accent, darkHeader, rounded, shadow and showTerms to TicketTemplate
- align PDF export with preview ticket data

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cc56b4d048322b3d5b99600269a34