### PR TITLE
Add terms section with dashed separator

### DIFF
--- a/src/components/ticket/TicketTemplate.jsx
+++ b/src/components/ticket/TicketTemplate.jsx
@@ -236,13 +236,13 @@ const TicketTemplate = forwardRef(({ data = {}, options = {} }, ref) => {
               <MiniQR image={qr} qrValue={qrValue} ticketId={ticketId} />
             </div>
           )}
-
-          {showTerms && terms && (
-            <div className="mt-6 text-[10px] text-gray-500">
-              <SafeText text={terms} />
-            </div>
-          )}
         </div>
+
+        {showTerms && terms && (
+          <div className="border-t border-dashed border-gray-300 px-6 py-4 text-[11px] text-gray-500">
+            <SafeText text={terms} />
+          </div>
+        )}
       </div>
     </ErrorBoundary>
   );


### PR DESCRIPTION
## Summary
- render ticket terms in dedicated bottom section with dashed divider

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cdc044d688322a9ff195db376e49c