### PR TITLE
Refactor ticket template to use built-in MiniQR

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "echarts": "^5.5.0",
     "echarts-for-react": "^3.0.2",
     "date-fns": "4.1.0",
-    "qrcode": "^1.5.3",
     "html-to-image": "^1.11.11",
     "jszip": "^3.10.1"
   },

--- a/src/components/admin/TicketLayoutSettings.jsx
+++ b/src/components/admin/TicketLayoutSettings.jsx
@@ -116,7 +116,6 @@ const TicketLayoutSettings = ({
         onDownload={onDownloadPreview}
         onRefresh={onRefreshPreview}
         ticketData={ticketData}
-        qrValue={ticketData?.qrValue}
       />
     </div>
   );

--- a/src/components/admin/TicketPreview.jsx
+++ b/src/components/admin/TicketPreview.jsx
@@ -2,8 +2,8 @@ import React, { useRef } from 'react';
 import { motion } from 'framer-motion';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../../common/SafeIcon';
-import TicketTemplate from '../ticket/TicketTemplate.jsx';
-import { buildTermsText } from '../../utils/ticketExport.js';
+import { TicketTemplate } from '../ticket';
+import { buildTermsText } from '../../utils/ticketExport';
 
 const { FiDownload, FiRefreshCw } = FiIcons;
 
@@ -18,7 +18,6 @@ const TicketPreview = ({
   showTerms = true,
   rounded,
   shadow,
-  qrValue,
   settings = {},
 }) => {
   const sampleTicket = {
@@ -35,7 +34,6 @@ const TicketPreview = ({
     currency: '₽',
     ticketId: 'TW-123456',
     ticketType: 'seat',
-    qrValue: 'TW-123456',
   };
 
   const t = { ...sampleTicket, ...(ticketData || {}) };
@@ -67,9 +65,7 @@ const TicketPreview = ({
     showQr,
     showTerms,
     rounded,
-    radius: rounded,
     shadow,
-    qrValue: qrValue || t.qrValue || t.ticketId,
   };
 
   return (

--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect, useMemo } from 'react';
 import * as FiIcons from 'react-icons/fi';
 import SafeIcon from '../../common/SafeIcon';
 import supabase from '../../lib/supabase';
-import { downloadTicketsPNG } from '../../utils/ticketExport.js';
+import { downloadTicketsPNG } from '../../utils/ticketExport';
 import { formatDateTime } from '../../utils/formatDateTime';
 import TicketLayoutSettings from './TicketLayoutSettings';
 import SMTPSettings from './SMTPSettings';
@@ -110,9 +110,6 @@ const TicketTemplateSettings = () => {
         : lastSoldTicket.zone
           ? 'zone'
           : 'general',
-      qrValue: lastSoldTicket.id
-        ? `T-${lastSoldTicket.id.substring(0, 8)}`
-        : '',
     };
   }, [lastSoldTicket, templateSettings]);
 

--- a/src/components/ticket/TicketDesigner.jsx
+++ b/src/components/ticket/TicketDesigner.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from 'react';
-import html2canvas from 'html2canvas';
-import TicketTemplate from './TicketTemplate.jsx';
+import { toPng } from 'html-to-image';
+import TicketTemplate from './TicketTemplate';
 
 const defaultData = {
   heroImage: '',
@@ -29,7 +29,6 @@ const defaultOptions = {
   showTerms: true,
   rounded: true,
   shadow: true,
-  qrValue: '',
 };
 
 const TicketDesigner = () => {
@@ -52,11 +51,15 @@ const TicketDesigner = () => {
 
   const exportPng = async () => {
     if (!previewRef.current) return;
-    const canvas = await html2canvas(previewRef.current);
-    const link = document.createElement('a');
-    link.download = 'ticket.png';
-    link.href = canvas.toDataURL('image/png');
-    link.click();
+    try {
+      const dataUrl = await toPng(previewRef.current);
+      const link = document.createElement('a');
+      link.download = 'ticket.png';
+      link.href = dataUrl;
+      link.click();
+    } catch (err) {
+      console.error('Error exporting ticket', err);
+    }
   };
 
   return (
@@ -123,16 +126,6 @@ const TicketDesigner = () => {
             onChange={handleOptionsChange}
           />
           <label htmlFor="showTerms">Show terms</label>
-        </div>
-        <div className="flex flex-col">
-          <label className="text-xs" htmlFor="qrValue">qrValue</label>
-          <input
-            id="qrValue"
-            name="qrValue"
-            className="border p-1 text-sm"
-            value={options.qrValue}
-            onChange={handleOptionsChange}
-          />
         </div>
         <button
           type="button"

--- a/src/components/ticket/TicketTemplate.jsx
+++ b/src/components/ticket/TicketTemplate.jsx
@@ -1,8 +1,7 @@
-import React, { forwardRef, useEffect, useState } from 'react';
-import QRCode from 'qrcode';
+import React, { forwardRef } from 'react';
 
 export const CARD_WIDTH = 560;
-export const HEADER_HEIGHT = 160;
+export const HEADER_HEIGHT = 192;
 
 const toStr = (val) => (val === undefined || val === null ? '' : String(val));
 
@@ -52,20 +51,15 @@ const Slot = ({ label, value, accent }) => {
   );
 };
 
-const MiniQR = ({ image, qrValue, ticketId }) => {
+const MiniQR = ({ image, ticketId }) => {
   if (!image) return null;
   return (
     <div className="flex flex-col items-center">
-      <div className="w-32 h-32 bg-gray-200 flex items-center justify-center">
+      <div className="w-32 h-32 bg-white flex items-center justify-center">
         <img src={image} alt="QR code" className="w-full h-full object-cover" />
       </div>
-      {qrValue && (
-        <div className="mt-2 text-xs text-gray-500">
-          <SafeText text={qrValue} />
-        </div>
-      )}
       {ticketId && (
-        <div className="text-xs text-gray-500">
+        <div className="mt-2 text-xs text-gray-500">
           <SafeText text={ticketId} />
         </div>
       )}
@@ -124,18 +118,7 @@ const TicketTemplate = forwardRef(({ data = {}, options = {} }, ref) => {
     showTerms = true,
     rounded = true,
     shadow = true,
-    qrValue,
   } = options;
-
-  const [qr, setQr] = useState(qrImage);
-
-  useEffect(() => {
-    if (!qr && showQr && qrValue) {
-      QRCode.toDataURL(String(qrValue))
-        .then(setQr)
-        .catch(() => {});
-    }
-  }, [qr, showQr, qrValue]);
 
   const isGA = !section && !row && !seat;
   const slotItems = [];
@@ -231,9 +214,9 @@ const TicketTemplate = forwardRef(({ data = {}, options = {} }, ref) => {
             </div>
           )}
 
-          {showQr && (
+          {showQr && qrImage && (
             <div className="mt-6 flex items-center justify-center">
-              <MiniQR image={qr} qrValue={qrValue} ticketId={ticketId} />
+              <MiniQR image={qrImage} ticketId={ticketId} />
             </div>
           )}
         </div>

--- a/src/components/ticket/index.js
+++ b/src/components/ticket/index.js
@@ -1,2 +1,2 @@
-export { default as TicketTemplate } from './TicketTemplate.jsx';
-export { default as TicketDesigner } from './TicketDesigner.jsx';
+export { default as TicketTemplate } from './TicketTemplate';
+export { default as TicketDesigner } from './TicketDesigner';

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -8,7 +8,7 @@ import EventWizard from '../components/events/EventWizard';
 import VenueDesigner from '../components/venue/VenueDesigner';
 import TicketTemplateSettings from '../components/admin/TicketTemplateSettings';
 import supabase from '../lib/supabase';
-import { downloadTicketsPNG } from '../utils/ticketExport.js';
+import { downloadTicketsPNG } from '../utils/ticketExport';
 
 const {
   FiUsers,

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { FiCheck, FiDownload, FiHome } from 'react-icons/fi';
 import SafeIcon from '../common/SafeIcon';
-import { downloadTicketsPNG } from '../utils/ticketExport.js';
+import { downloadTicketsPNG } from '../utils/ticketExport';
 
 const ThankYouPage = () => {
   const navigate = useNavigate();

--- a/src/utils/ticketExport.js
+++ b/src/utils/ticketExport.js
@@ -2,7 +2,7 @@ import { toPng } from 'html-to-image';
 import JSZip from 'jszip';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import TicketTemplate from '../components/ticket/TicketTemplate.jsx';
+import { TicketTemplate } from '../components/ticket';
 
 export function buildTermsText(order = {}, settings = {}) {
   const eventNote = order?.event?.note;
@@ -93,7 +93,6 @@ export async function downloadTicketsPNG(order, baseFileName = 'ticket', templat
       showTerms: settings.ticketContent?.showTerms,
       rounded: settings.design?.rounded,
       shadow: settings.design?.shadow,
-      qrValue: order.orderNumber || seatInfo.id,
     };
 
     const markup = renderToStaticMarkup(


### PR DESCRIPTION
## Summary
- rebuild `TicketTemplate` with new constants and internal MiniQR component, removing qrcode usage
- simplify `TicketDesigner` and admin preview components to align with new template and drop html2canvas
- remove `qrcode` dependency and update ticket export utilities

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cde2257488322b8cd66b45bf5bb0d