### PR TITLE
feat: add optional ticket recreation

### DIFF
--- a/database-setup.sql
+++ b/database-setup.sql
@@ -91,8 +91,13 @@ BEGIN
     RAISE EXCEPTION 'Event has no venue assigned';
   END IF;
 
-  -- Удаляем существующие билеты для этого события
-  DELETE FROM tickets WHERE event_id = p_event_id;
+  -- Проверяем наличие проданных билетов
+  IF EXISTS (SELECT 1 FROM tickets WHERE event_id = p_event_id AND status = 'sold') THEN
+    RAISE EXCEPTION 'Cannot recreate tickets: sold tickets exist';
+  END IF;
+
+  -- Удаляем только свободные и удержанные билеты
+  DELETE FROM tickets WHERE event_id = p_event_id AND status IN ('free', 'held');
 
   -- Создаем билеты для зон (sections/polygons)
   FOR v_zone_record IN 


### PR DESCRIPTION
## Summary
- allow event updates without recreating tickets unless venue changes or explicitly requested
- add UI toggle to recreate tickets with warning about sales loss
- protect sold tickets in SQL function and delete only free/held ones

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d0e124e708322bb2aecf829a6bc0b