### PR TITLE
Make ticket header overlay transparent for hero image

### DIFF
--- a/src/components/ticket/TicketTemplate.jsx
+++ b/src/components/ticket/TicketTemplate.jsx
@@ -149,21 +149,21 @@ const TicketTemplate = forwardRef(({ data = {}, options = {} }, ref) => {
               data-slot="heroImage"
               src={heroImage}
               alt=""
-              className="absolute inset-0 w-full h-full object-cover"
+              className="absolute inset-0 w-full h-full object-cover z-0"
             />
           )}
           <div
             className={[
-              'absolute inset-0',
+              'absolute inset-0 z-10',
               darkHeader
-                ? 'bg-black/70'
-                : 'bg-gradient-to-b from-transparent via-black/30 to-black/70',
+                ? 'bg-black/60'
+                : 'bg-gradient-to-b from-black/20 via-black/40 to-black/80',
             ].join(' ')}
           />
           {brand && (
             <span
               data-slot="brand"
-              className="absolute top-4 left-4 px-2 py-1 text-white text-xs font-semibold rounded"
+              className="absolute top-4 left-4 z-20 px-2 py-1 text-white text-xs font-semibold rounded"
               style={accent ? { backgroundColor: accent } : { backgroundColor: '#000000b3' }}
             >
               {brand}

--- a/src/components/ticket/TicketTemplate.test.js
+++ b/src/components/ticket/TicketTemplate.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+// Extract sanitizeTicket from the JSX file without parsing the entire React component
+const loadSanitizeTicket = async () => {
+  const code = await fs.readFile(new URL('./TicketTemplate.jsx', import.meta.url), 'utf8');
+  const start = code.indexOf('const toStr');
+  const end = code.indexOf('const SafeText');
+  const snippet = code.slice(start, end);
+  return import(`data:text/javascript;base64,${Buffer.from(snippet).toString('base64')}`);
+};
+
+test('sanitizeTicket preserves heroImage strings', async () => {
+  const { sanitizeTicket } = await loadSanitizeTicket();
+  const base64 = 'data:image/png;base64,ABC123';
+  const url = 'https://example.com/image.jpg';
+  assert.equal(sanitizeTicket({ heroImage: base64 }).heroImage, base64);
+  assert.equal(sanitizeTicket({ heroImage: url }).heroImage, url);
+});


### PR DESCRIPTION
## Summary
- Tweak ticket header overlay to use a partially transparent gradient and define stacking order
- Add unit test ensuring `sanitizeTicket` preserves hero image strings

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d22b84c548322b4b484f5b83f0370