### PR TITLE
feat: add qr value rendering

### DIFF
--- a/src/components/admin/TicketPreview.jsx
+++ b/src/components/admin/TicketPreview.jsx
@@ -32,7 +32,7 @@ const TicketPreview = ({
     seat: '12',
     price: '2500',
     currency: '₽',
-    ticketId: 'TW-123456',
+    qrValue: 'TW-123456',
     ticketType: 'seat',
   };
 
@@ -53,7 +53,7 @@ const TicketPreview = ({
     seat: t.seat,
     price: t.price,
     currency: t.currency,
-    ticketId: t.ticketId,
+    qrValue: t.qrValue,
     ticketType: t.ticketType,
     terms: buildTermsText({}, settings),
   };

--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -102,7 +102,7 @@ const TicketTemplateSettings = () => {
         ? parseFloat(lastSoldTicket.order_item.unit_price).toFixed(2)
         : '',
       currency: '€',
-      ticketId: lastSoldTicket.id
+      qrValue: lastSoldTicket.id
         ? `T-${lastSoldTicket.id.substring(0, 8)}`
         : '',
       ticketType: lastSoldTicket.seat

--- a/src/components/ticket/TicketDesigner.jsx
+++ b/src/components/ticket/TicketDesigner.jsx
@@ -16,8 +16,7 @@ const defaultData = {
   gate: '',
   price: '',
   currency: '',
-  qrImage: '',
-  ticketId: '',
+  qrValue: '',
   terms: '',
 };
 
@@ -66,7 +65,7 @@ const TicketDesigner = () => {
           seat_number: data.seat,
           gate: data.gate,
           price: data.price,
-          id: data.ticketId,
+          id: data.qrValue,
         },
       ],
       currency: data.currency,

--- a/src/components/ticket/TicketTemplate.jsx
+++ b/src/components/ticket/TicketTemplate.jsx
@@ -20,8 +20,7 @@ export function sanitizeTicket(data = {}) {
     'gate',
     'price',
     'currency',
-    'qrImage',
-    'ticketId',
+    'qrValue',
     'terms',
   ];
   const result = {};
@@ -38,23 +37,25 @@ const SafeText = ({ text, className, ...props }) => (
   </span>
 );
 
-const MiniQR = ({ image, ticketId }) => {
-  if (!image) return null;
+const MiniQR = ({ value }) => {
+  if (!value) return null;
+  const src = `https://api.qrserver.com/v1/create-qr-code/?data=${encodeURIComponent(value)}&size=164x164`;
   return (
     <div className="flex flex-col items-center">
-      <div className="w-32 h-32 bg-white flex items-center justify-center">
-        <img
-          data-slot="qrImage"
-          src={image}
-          alt="QR code"
-          className="w-full h-full object-cover"
-        />
-      </div>
-      {ticketId && (
-        <div className="mt-2 text-xs text-gray-500">
-          <SafeText data-slot="ticketId" text={ticketId} />
+      <div className="rounded-xl border p-3">
+        <div className="w-[164px] h-[164px] border flex items-center justify-center">
+          <img
+            data-slot="qrValue"
+            src={src}
+            alt="QR code"
+            className="w-full h-full object-cover"
+            crossOrigin="anonymous"
+          />
         </div>
-      )}
+      </div>
+      <div className="mt-2 text-xs text-gray-500">
+        <SafeText data-slot="qrValue (text)" text={value} />
+      </div>
     </div>
   );
 };
@@ -96,8 +97,7 @@ const TicketTemplate = forwardRef(({ data = {}, options = {} }, ref) => {
     seat,
     price,
     currency,
-    qrImage,
-    ticketId,
+    qrValue,
     terms,
   } = ticket;
 
@@ -236,9 +236,9 @@ const TicketTemplate = forwardRef(({ data = {}, options = {} }, ref) => {
               </div>
             )}
 
-            {showQr && qrImage && (
+            {showQr && qrValue && (
               <div className="mt-6 flex items-center justify-center">
-                <MiniQR image={qrImage} ticketId={ticketId} />
+                <MiniQR value={qrValue} />
               </div>
             )}
           </div>

--- a/src/components/ticket/TicketTemplate.test.js
+++ b/src/components/ticket/TicketTemplate.test.js
@@ -18,3 +18,8 @@ test('sanitizeTicket preserves heroImage strings', async () => {
   assert.equal(sanitizeTicket({ heroImage: base64 }).heroImage, base64);
   assert.equal(sanitizeTicket({ heroImage: url }).heroImage, url);
 });
+
+test('sanitizeTicket stringifies qrValue', async () => {
+  const { sanitizeTicket } = await loadSanitizeTicket();
+  assert.equal(sanitizeTicket({ qrValue: 123 }).qrValue, '123');
+});

--- a/src/utils/ticketExport/index.js
+++ b/src/utils/ticketExport/index.js
@@ -99,7 +99,7 @@ export async function downloadTicketsPDF(order, baseFileName = 'ticket', templat
       gate: seatInfo.gate,
       price: seatInfo.price || order.price,
       currency: order.currency,
-      ticketId: seatInfo.id || order.orderNumber,
+      qrValue: seatInfo.id || order.orderNumber,
       terms: buildTermsText(order, settings),
     };
 


### PR DESCRIPTION
## Summary
- include `qrValue` in ticket sanitization and render a styled QR block with matching text
- pass `qrValue` through designer, preview, and export utilities
- add unit test for `qrValue` sanitization

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d261c5fc8832292311adcd876e4ce