### PR TITLE
Show ticket ID when QR code hidden

### DIFF
--- a/src/components/ticket/TicketTemplate.jsx
+++ b/src/components/ticket/TicketTemplate.jsx
@@ -241,6 +241,11 @@ const TicketTemplate = forwardRef(({ data = {}, options = {} }, ref) => {
                 <MiniQR value={qrValue} />
               </div>
             )}
+            {qrValue && (
+              <div className="mt-2 text-xs text-gray-500 text-center">
+                <SafeText data-slot="ticketId" text={qrValue} />
+              </div>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Always display ticket ID text after QR value so it's visible even when QR code is hidden

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2874928483228561c9189cbce2b1