### PR TITLE
Preserve seat metadata through checkout flow

### DIFF
--- a/src/pages/CheckoutPage.jsx
+++ b/src/pages/CheckoutPage.jsx
@@ -59,7 +59,12 @@ const CheckoutPage=()=> {
 
     if (storedSeats) {
       try {
-        const parsedSeats=JSON.parse(storedSeats);
+        const parsedSeats=JSON.parse(storedSeats).map(seat=> ({
+          ...seat,
+          section: seat.section,
+          row_number: seat.row_number ?? seat.row,
+          seat_number: seat.seat_number ?? seat.number ?? seat.label
+        }));
         console.log('🎫 Loaded seats from sessionStorage:',parsedSeats);
         setSelectedSeats(parsedSeats);
       } catch (error) {
@@ -348,7 +353,12 @@ const CheckoutPage=()=> {
 
         // Store order summary in sessionStorage for thank you page
         sessionStorage.setItem('orderSummary',JSON.stringify({
-          seats: selectedSeats,
+          seats: selectedSeats.map(seat=> ({
+            ...seat,
+            section: seat.section,
+            row_number: seat.row_number,
+            seat_number: seat.seat_number
+          })),
           event: eventDetails,
           totalPrice: calculateTotal(),
           orderNumber: `TW-${order.id.substring(0,6)}`,
@@ -387,7 +397,12 @@ const CheckoutPage=()=> {
 
         // Store order summary in sessionStorage for thank you page
         sessionStorage.setItem('orderSummary',JSON.stringify({
-          seats: selectedSeats,
+          seats: selectedSeats.map(seat=> ({
+            ...seat,
+            section: seat.section,
+            row_number: seat.row_number,
+            seat_number: seat.seat_number
+          })),
           event: eventDetails,
           totalPrice: calculateTotal(),
           orderNumber: `TW-${order.id.substring(0,6)}`,

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -63,6 +63,12 @@ const ThankYouPage = () => {
     if (orderSummary) {
       const orderData = {
         ...orderSummary,
+        seats: orderSummary.seats?.map(seat => ({
+          ...seat,
+          section: seat.section,
+          row_number: seat.row_number,
+          seat_number: seat.seat_number
+        })),
         company: {
           name: templateSettings?.companyInfo?.brand || 'TicketWayz',
         },
@@ -109,12 +115,21 @@ const ThankYouPage = () => {
             </>
           )}
           {orderSummary && orderSummary.seats && (
-            <div className="flex justify-between mb-2">
-              <span className="text-zinc-400">Билеты:</span>
-              <span>
-                {orderSummary.seats.length} шт.
-              </span>
-            </div>
+            <>
+              <div className="flex justify-between mb-2">
+                <span className="text-zinc-400">Билеты:</span>
+                <span>
+                  {orderSummary.seats.length} шт.
+                </span>
+              </div>
+              <div className="text-sm text-left text-zinc-400 space-y-1 mb-2">
+                {orderSummary.seats.map(seat => (
+                  <div key={seat.id}>
+                    Секция {seat.section || '-'}, ряд {seat.row_number || '-'}, место {seat.seat_number || seat.number || '-'}
+                  </div>
+                ))}
+              </div>
+            </>
           )}
           <div className="flex justify-between font-medium pt-2 border-t border-zinc-600">
             <span>Итого:</span>

--- a/src/pages/VenuePage.jsx
+++ b/src/pages/VenuePage.jsx
@@ -421,7 +421,10 @@ quantity: seat.quantity,
 price: seat.totalPrice,
 unitPrice: seat.unitPrice,
 categoryId: seat.categoryId,
-type: seat.type
+type: seat.type,
+section: seat.section,
+row_number: seat.row,
+seat_number: seat.number
 }));
 
 console.log('🚀 Proceeding to checkout with seats:',seatsForCheckout);


### PR DESCRIPTION
## Summary
- Persist seat section, row, and number when proceeding from venue to checkout
- Rehydrate and store seat details throughout checkout including Apple Pay flow
- Pass detailed seat info to ticket export and display it on the thank-you page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dd7bc4e5c832292ffdd120e166240