### PR TITLE
Preserve zone information across checkout

### DIFF
--- a/src/pages/CheckoutPage.jsx
+++ b/src/pages/CheckoutPage.jsx
@@ -62,8 +62,8 @@ const CheckoutPage=()=> {
         const parsedSeats=JSON.parse(storedSeats).map(seat=> ({
           ...seat,
           section: seat.section,
-          row_number: seat.row_number ?? seat.row,
-          seat_number: seat.seat_number ?? seat.number ?? seat.label
+          row_number: seat.row_number ?? (seat.type==='seat' ? seat.row : undefined),
+          seat_number: seat.seat_number ?? (seat.type==='seat' ? seat.number : undefined)
         }));
         console.log('🎫 Loaded seats from sessionStorage:',parsedSeats);
         setSelectedSeats(parsedSeats);

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -125,7 +125,9 @@ const ThankYouPage = () => {
               <div className="text-sm text-left text-zinc-400 space-y-1 mb-2">
                 {orderSummary.seats.map(seat => (
                   <div key={seat.id}>
-                    Секция {seat.section || '-'}, ряд {seat.row_number || '-'}, место {seat.seat_number || seat.number || '-'}
+                    {seat.row_number && seat.seat_number
+                      ? `Секция ${seat.section || '-'}, ряд ${seat.row_number || '-'}, место ${seat.seat_number || seat.number || '-'}`
+                      : `Секция ${seat.section || '-'}`}
                   </div>
                 ))}
               </div>

--- a/src/pages/VenuePage.jsx
+++ b/src/pages/VenuePage.jsx
@@ -74,7 +74,7 @@ type: seat.type || 'seat',
 number: seat.number || seat.label || `Место ${seat.id.substring(0,4)}`,
 price: actualUnitPrice * quantity,
 // ДОБАВЛЯЕМ поля для отображения в корзине
-section: seat.section || 'A',
+section: seat.section ?? seat.zoneName ?? seat.label,
 row: seat.row || 1
 };
 };
@@ -422,7 +422,7 @@ price: seat.totalPrice,
 unitPrice: seat.unitPrice,
 categoryId: seat.categoryId,
 type: seat.type,
-section: seat.section,
+ section: seat.section || seat.zoneName,
 row_number: seat.row,
 seat_number: seat.number
 }));
@@ -522,6 +522,7 @@ id: `${selectedCapacityElement.id}-${Date.now()}`,
 elementId: selectedCapacityElement.id,
 number: `${selectedCapacityElement.label || 'Zone'} (${capacityToSelect} мест)`,
 label: `${selectedCapacityElement.label || 'Zone'} (${capacityToSelect} мест)`,
+zoneName: selectedCapacityElement.label,
 categoryId: selectedCapacityElement.categoryId,
 quantity: capacityToSelect,
 type: selectedCapacityElement.type

--- a/src/utils/ticketExport/index.js
+++ b/src/utils/ticketExport/index.js
@@ -93,7 +93,7 @@ export async function downloadTicketsPDF(order, baseFileName = 'ticket', templat
       time,
       venue: event.location,
       address: event.address,
-      section: seatInfo.section,
+      section: seatInfo.section || seatInfo.zoneName || seatInfo.zone?.name,
       row: seatInfo.row_number,
       seat: seatInfo.seat_number,
       price: seatInfo.price || order.price,


### PR DESCRIPTION
## Summary
- Ensure cart items use zone names as section labels and persist them through checkout
- Retain section data in stored seats and order summaries
- Render zone-based tickets by section when row or seat numbers are absent and expose zone names in exported PDFs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ddc5be828832282a93355c99b5fc5