### PR TITLE
Ensure ticket terms appear in exported PDFs

### DIFF
--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -406,7 +406,15 @@ const TicketTemplateSettings = () => {
     setSaving(true);
     setError(null);
     try {
-      localStorage.setItem('ticketTemplateSettings', JSON.stringify(templateSettings));
+      const settingsToSave = {
+        ...templateSettings,
+        ticketContent: {
+          ...templateSettings.ticketContent,
+          showTerms: true,
+        },
+      };
+      localStorage.setItem('ticketTemplateSettings', JSON.stringify(settingsToSave));
+      setTemplateSettings(settingsToSave);
       localStorage.setItem('smtpSettings', JSON.stringify(smtpSettings));
       localStorage.setItem('emailSettings', JSON.stringify(emailSettings));
       setSuccess(true);

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -78,7 +78,14 @@ const ThankYouPage = () => {
         },
         currency: orderSummary.currency || '€',
       };
-      downloadTicketsPDF(orderData, `tickets-${orderNumber}`, templateSettings);
+      const settings = {
+        ...templateSettings,
+        ticketContent: {
+          ...templateSettings?.ticketContent,
+          showTerms: true,
+        },
+      };
+      downloadTicketsPDF(orderData, `tickets-${orderNumber}`, settings);
     }
   };
 


### PR DESCRIPTION
## Summary
- Merge runtime template flags in Thank You page and enforce `showTerms` when downloading tickets
- Persist enforced `showTerms` flag when saving template settings to keep preview and PDF aligned

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ded3a2e688322a9cbfa7321227393