### PR TITLE
Normalize relative image URLs in ticket export

### DIFF
--- a/src/utils/ticketExport/index.js
+++ b/src/utils/ticketExport/index.js
@@ -30,7 +30,9 @@ export function buildTermsText(order = {}, settings = {}) {
 export function validateImageUrl(url) {
   if (!url) return null;
   if (url.startsWith('data:image')) return url;
-  if (url.startsWith('/')) return new URL(url, window.location.origin).href;
+  if (!/^https?:/i.test(url)) {
+    return new URL(url, window.location.origin).href;
+  }
   try {
     const { protocol } = new URL(url);
     if (protocol === 'http:' || protocol === 'https:') return url;


### PR DESCRIPTION
## Summary
- Normalize non-absolute hero/event image URLs relative to window origin
- Preserve cross-origin loading for ticket hero images

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dee40e2cc83228309c1d1bac4582f