### PR TITLE
Warn on missing event media

### DIFF
--- a/src/pages/CheckoutPage.jsx
+++ b/src/pages/CheckoutPage.jsx
@@ -78,7 +78,16 @@ const CheckoutPage=()=> {
 
     if (storedEventDetails) {
       try {
-        setEventDetails(JSON.parse(storedEventDetails));
+        const parsedEvent=JSON.parse(storedEventDetails);
+        if (!parsedEvent.image) {
+          console.warn('Missing event.image in sessionStorage');
+          parsedEvent.image=null;
+        }
+        if (!parsedEvent.note) {
+          console.warn('Missing event.note in sessionStorage');
+          parsedEvent.note='';
+        }
+        setEventDetails(parsedEvent);
       } catch (error) {
         console.error('Error parsing event details:',error);
       }
@@ -352,6 +361,13 @@ const CheckoutPage=()=> {
         const order=await createOrder();
 
         // Store order summary in sessionStorage for thank you page
+        const eventForSummary={
+          ...eventDetails,
+          image: eventDetails?.image || null,
+          note: eventDetails?.note || ''
+        };
+        if (!eventDetails?.image) console.warn('Missing event.image when building order summary');
+        if (!eventDetails?.note) console.warn('Missing event.note when building order summary');
         sessionStorage.setItem('orderSummary',JSON.stringify({
           seats: selectedSeats.map(seat=> ({
             ...seat,
@@ -359,7 +375,7 @@ const CheckoutPage=()=> {
             row_number: seat.row_number,
             seat_number: seat.seat_number
           })),
-          event: { ...eventDetails, image: eventDetails?.image },
+          event: eventForSummary,
           totalPrice: calculateTotal(),
           orderNumber: `TW-${order.id.substring(0,6)}`,
           customerInfo: {
@@ -396,6 +412,13 @@ const CheckoutPage=()=> {
         const order=await createOrder();
 
         // Store order summary in sessionStorage for thank you page
+        const eventForSummary={
+          ...eventDetails,
+          image: eventDetails?.image || null,
+          note: eventDetails?.note || ''
+        };
+        if (!eventDetails?.image) console.warn('Missing event.image when building order summary');
+        if (!eventDetails?.note) console.warn('Missing event.note when building order summary');
         sessionStorage.setItem('orderSummary',JSON.stringify({
           seats: selectedSeats.map(seat=> ({
             ...seat,
@@ -403,7 +426,7 @@ const CheckoutPage=()=> {
             row_number: seat.row_number,
             seat_number: seat.seat_number
           })),
-          event: { ...eventDetails, image: eventDetails?.image },
+          event: eventForSummary,
           totalPrice: calculateTotal(),
           orderNumber: `TW-${order.id.substring(0,6)}`,
           paymentMethod: 'Apple Pay',

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -16,7 +16,16 @@ const ThankYouPage = () => {
     const storedOrderSummary = sessionStorage.getItem('orderSummary');
     if (storedOrderSummary) {
       try {
-        setOrderSummary(JSON.parse(storedOrderSummary));
+        const parsedSummary = JSON.parse(storedOrderSummary);
+        if (!parsedSummary?.event?.image) {
+          console.warn('Missing event.image in order summary');
+          parsedSummary.event = { ...parsedSummary.event, image: null };
+        }
+        if (!parsedSummary?.event?.note) {
+          console.warn('Missing event.note in order summary');
+          parsedSummary.event = { ...parsedSummary.event, note: '' };
+        }
+        setOrderSummary(parsedSummary);
       } catch (error) {
         console.error('Error parsing order summary:', error);
       }
@@ -61,11 +70,14 @@ const ThankYouPage = () => {
 
   const handleDownload = () => {
     if (orderSummary) {
+      if (!orderSummary.event?.image) console.warn('Missing event.image before PDF generation');
+      if (!orderSummary.event?.note) console.warn('Missing event.note before PDF generation');
       const orderData = {
         ...orderSummary,
         event: {
           ...orderSummary.event,
-          image: orderSummary.event?.image,
+          image: orderSummary.event?.image || null,
+          note: orderSummary.event?.note || '',
         },
         seats: orderSummary.seats?.map(seat => ({
           ...seat,

--- a/src/pages/VenuePage.jsx
+++ b/src/pages/VenuePage.jsx
@@ -431,14 +431,18 @@ console.log('🚀 Proceeding to checkout with seats:',seatsForCheckout);
 
 // Store selected seats in sessionStorage to access them in checkout
 sessionStorage.setItem('selectedSeats',JSON.stringify(seatsForCheckout));
+  const eventImage = event.image || null;
+  const eventNote = event.note || '';
+  if (!event.image) console.warn('Missing event.image for event', event.id);
+  if (!event.note) console.warn('Missing event.note for event', event.id);
   sessionStorage.setItem('eventDetails',JSON.stringify({
   id: event.id,
   title: event.title,
   date: event.event_date,
   location: event.location,
   venue: venue?.name,
-  note: event.note,
-  image: event.image
+  note: eventNote,
+  image: eventImage
 }));
 
 navigate('/checkout');


### PR DESCRIPTION
## Summary
- Warn and provide fallbacks for missing event image or note in VenuePage when storing session data
- Validate and warn about missing event media in CheckoutPage, ensuring order summaries include placeholders
- Add warnings and placeholders in ThankYouPage when reading order summaries and generating ticket data

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689def0093548322848c93e27f5b27dd