### PR TITLE
Simplify ticket terms handling

### DIFF
--- a/src/components/admin/TicketLayoutSettings.jsx
+++ b/src/components/admin/TicketLayoutSettings.jsx
@@ -93,15 +93,6 @@ const TicketLayoutSettings = ({
           <span className="text-sm text-zinc-700 dark:text-zinc-300">Show QR</span>
         </label>
 
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            className="rounded border-zinc-300 dark:border-zinc-600"
-            checked={settings.ticketContent.showTerms}
-            onChange={handle('ticketContent', 'showTerms')}
-          />
-          <span className="text-sm text-zinc-700 dark:text-zinc-300">Show terms</span>
-        </label>
       </div>
 
       <TicketPreview
@@ -112,7 +103,6 @@ const TicketLayoutSettings = ({
         shadow={settings.design.shadow}
         showPrice={settings.ticketContent.showPrice}
         showQr={settings.design.showQRCode}
-        showTerms={settings.ticketContent.showTerms}
         onDownload={onDownloadPreview}
         onRefresh={onRefreshPreview}
         ticketData={ticketData}

--- a/src/components/admin/TicketPreview.jsx
+++ b/src/components/admin/TicketPreview.jsx
@@ -15,7 +15,6 @@ const TicketPreview = ({
   darkHeader,
   showPrice = true,
   showQr = true,
-  showTerms = true,
   rounded,
   shadow,
   settings = {},
@@ -82,7 +81,6 @@ const TicketPreview = ({
     ticketContent: {
       ...(settings.ticketContent || {}),
       showPrice,
-      showTerms,
     },
   };
 

--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -57,7 +57,6 @@ const TicketTemplateSettings = () => {
       showVenueInfo: true,
       showDateTime: true,
       showPrice: true,
-      showTerms: true,
       customInstructions: '',
       termsAndConditions: '',
       additionalFields: []
@@ -410,7 +409,6 @@ const TicketTemplateSettings = () => {
         ...templateSettings,
         ticketContent: {
           ...templateSettings.ticketContent,
-          showTerms: true,
         },
       };
       localStorage.setItem('ticketTemplateSettings', JSON.stringify(settingsToSave));
@@ -458,7 +456,6 @@ const TicketTemplateSettings = () => {
           showVenueInfo: true,
           showDateTime: true,
           showPrice: true,
-          showTerms: true,
           customInstructions: '',
           termsAndConditions: '',
           additionalFields: []

--- a/src/components/ticket/TicketDesigner.jsx
+++ b/src/components/ticket/TicketDesigner.jsx
@@ -24,7 +24,6 @@ const defaultOptions = {
   darkHeader: false,
   showPrice: true,
   showQr: true,
-  showTerms: true,
   rounded: true,
   shadow: true,
 };
@@ -80,7 +79,6 @@ const TicketDesigner = () => {
       },
       ticketContent: {
         showPrice: options.showPrice,
-        showTerms: options.showTerms,
       },
     };
 
@@ -141,16 +139,6 @@ const TicketDesigner = () => {
             onChange={handleOptionsChange}
           />
           <label htmlFor="showQr">Show QR</label>
-        </div>
-        <div className="flex items-center gap-2 text-sm">
-          <input
-            id="showTerms"
-            type="checkbox"
-            name="showTerms"
-            checked={options.showTerms}
-            onChange={handleOptionsChange}
-          />
-          <label htmlFor="showTerms">Show terms</label>
         </div>
         <button
           type="button"

--- a/src/components/ticket/TicketTemplate.jsx
+++ b/src/components/ticket/TicketTemplate.jsx
@@ -110,7 +110,7 @@ const TicketTemplate = forwardRef(({ data = {}, options = {} }, ref) => {
 
   const actualTicketId = ticketId || qrValue;
 
-  const { showPrice = true, showQr = true, showTerms = true } = options;
+  const { showPrice = true, showQr = true } = options;
 
   return (
     <ErrorBoundary>
@@ -225,7 +225,7 @@ const TicketTemplate = forwardRef(({ data = {}, options = {} }, ref) => {
           </div>
         </div>
 
-        {showTerms && terms && (
+        {terms && (
           <div className="border-t border-dashed border-gray-300 px-6 py-4 text-[11px] text-gray-500">
             <SafeText data-slot="terms" text={terms} />
           </div>

--- a/src/components/ticket/TicketTemplatePDF.jsx
+++ b/src/components/ticket/TicketTemplatePDF.jsx
@@ -120,7 +120,7 @@ const TicketTemplatePDF = ({ data = {}, options = {} }) => {
   } = ticket;
 
   const actualTicketId = ticketId || qrValue;
-  const { showPrice = true, showQr = true, showTerms = true } = options;
+  const { showPrice = true, showQr = true } = options;
   const qrSrc = qrImage || (qrValue ? `https://api.qrserver.com/v1/create-qr-code/?data=${encodeURIComponent(qrValue)}&size=164x164` : null);
 
   return (
@@ -187,7 +187,7 @@ const TicketTemplatePDF = ({ data = {}, options = {} }) => {
             <Text style={styles.ticketId}>{qrValue}</Text>
           )}
 
-          {showTerms && terms && <Text style={styles.terms}>{terms}</Text>}
+          {terms && <Text style={styles.terms}>{terms}</Text>}
         </View>
       </View>
     </Page>

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -94,7 +94,6 @@ const ThankYouPage = () => {
         ...templateSettings,
         ticketContent: {
           ...templateSettings?.ticketContent,
-          showTerms: true,
         },
       };
       downloadTicketsPDF(orderData, `tickets-${orderNumber}`, settings);

--- a/src/utils/ticketExport/index.js
+++ b/src/utils/ticketExport/index.js
@@ -3,25 +3,6 @@ import { pdf, Document } from '@react-pdf/renderer';
 import { TicketTemplatePDF } from '../../components/ticket';
 
 /**
- * Combine event notes and custom text into a single terms string.
- * @param {Object} [order={}] Order data containing event info and terms
- * @param {Object} [settings={}] Template settings that may include custom text
- * @returns {string} Joined terms text
- */
-export function buildTermsText(order = {}, settings = {}) {
-  const eventNote = order?.event?.note;
-  const ticketContent = settings.ticketContent || {};
-  return [
-    eventNote,
-    ticketContent.customInstructions,
-    ticketContent.termsAndConditions,
-    order?.terms,
-  ]
-    .filter(Boolean)
-    .join(' ');
-}
-
-/**
  * Build TicketTemplate props from order, seat and settings objects.
  * @param {Object} [order={}] Order data
  * @param {Object} [seat={}] Seat-specific data
@@ -59,7 +40,7 @@ export function buildTicketTemplateProps(order = {}, seat = {}, settings = {}) {
     currency: order.currency,
     qrValue: seatInfo.id || order.orderNumber || order.qrValue,
     ticketType: seatInfo.ticketType || seatInfo.type || order.ticketType,
-    terms: buildTermsText(order, settings),
+    terms: order?.event?.note || '',
   };
 
   const options = {
@@ -67,7 +48,7 @@ export function buildTicketTemplateProps(order = {}, seat = {}, settings = {}) {
     darkHeader: design.darkHeader,
     showPrice: ticketContent.showPrice,
     showQr: design.showQRCode,
-    showTerms: ticketContent.showTerms ?? true,
+    showTerms: Boolean(order?.event?.note),
     rounded: design.rounded,
     shadow: design.shadow,
     scale: settings.scale || design.scale,


### PR DESCRIPTION
## Summary
- build ticket props with terms from event note and show terms when note exists
- remove showTerms toggle from templates and admin views
- always render terms block when provided

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689df8b437608322bd38b664a373dedd