### PR TITLE
Use event cover image for tickets

### DIFF
--- a/src/utils/ticketExport/index.js
+++ b/src/utils/ticketExport/index.js
@@ -26,7 +26,7 @@ export function buildTicketTemplateProps(order = {}, seat = {}, settings = {}) {
       : order.time;
 
   const data = {
-    heroImage: design.heroUrl || event.image || order.heroImage,
+    heroImage: event.image,
     brand: company.name || order.brand,
     artist: event.title || order.artist,
     date,


### PR DESCRIPTION
## Summary
- Remove fallback hero image sources for ticket exports
- Use event.image as the sole hero image

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e0fd913f8832299c97e6b1ac4b9c4