### PR TITLE
Use event note when building ticket PDFs

### DIFF
--- a/src/pages/CheckoutPage.jsx
+++ b/src/pages/CheckoutPage.jsx
@@ -361,14 +361,14 @@ const CheckoutPage=()=> {
         const order=await createOrder();
 
         // Store order summary in sessionStorage for thank you page
-        const eventForSummary={
+        const eventForSummary = {
           ...eventDetails,
           image: eventDetails?.image || null,
-          note: eventDetails?.note || ''
+          note: eventDetails?.note || '',
         };
         if (!eventDetails?.image) console.warn('Missing event.image when building order summary');
         if (!eventDetails?.note) console.warn('Missing event.note when building order summary');
-        sessionStorage.setItem('orderSummary',JSON.stringify({
+        sessionStorage.setItem('orderSummary', JSON.stringify({
           seats: selectedSeats.map(seat=> ({
             ...seat,
             section: seat.section,
@@ -412,14 +412,14 @@ const CheckoutPage=()=> {
         const order=await createOrder();
 
         // Store order summary in sessionStorage for thank you page
-        const eventForSummary={
+        const eventForSummary = {
           ...eventDetails,
           image: eventDetails?.image || null,
-          note: eventDetails?.note || ''
+          note: eventDetails?.note || '',
         };
         if (!eventDetails?.image) console.warn('Missing event.image when building order summary');
         if (!eventDetails?.note) console.warn('Missing event.note when building order summary');
-        sessionStorage.setItem('orderSummary',JSON.stringify({
+        sessionStorage.setItem('orderSummary', JSON.stringify({
           seats: selectedSeats.map(seat=> ({
             ...seat,
             section: seat.section,

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -21,10 +21,11 @@ const ThankYouPage = () => {
           console.warn('Missing event.image in order summary');
           parsedSummary.event = { ...parsedSummary.event, image: null };
         }
+        const note = parsedSummary?.event?.note || '';
         if (!parsedSummary?.event?.note) {
           console.warn('Missing event.note in order summary');
-          parsedSummary.event = { ...parsedSummary.event, note: '' };
         }
+        parsedSummary.event = { ...parsedSummary.event, note };
         setOrderSummary(parsedSummary);
       } catch (error) {
         console.error('Error parsing order summary:', error);
@@ -72,13 +73,14 @@ const ThankYouPage = () => {
     if (orderSummary) {
       if (!orderSummary.event?.image) console.warn('Missing event.image before PDF generation');
       if (!orderSummary.event?.note) console.warn('Missing event.note before PDF generation');
+      const eventWithNote = {
+        ...orderSummary.event,
+        image: orderSummary.event?.image || null,
+        note: orderSummary.event?.note || '',
+      };
       const orderData = {
         ...orderSummary,
-        event: {
-          ...orderSummary.event,
-          image: orderSummary.event?.image || null,
-          note: orderSummary.event?.note || '',
-        },
+        event: eventWithNote,
         seats: orderSummary.seats?.map(seat => ({
           ...seat,
           section: seat.section,

--- a/src/utils/ticketExport/index.js
+++ b/src/utils/ticketExport/index.js
@@ -40,7 +40,7 @@ export function buildTicketTemplateProps(order = {}, seat = {}, settings = {}) {
     currency: order.currency,
     qrValue: seatInfo.id || order.orderNumber || order.qrValue,
     ticketType: seatInfo.ticketType || seatInfo.type || order.ticketType,
-    terms: order?.event?.note || '',
+    terms: event.note || '',
   };
 
   const options = {
@@ -48,7 +48,7 @@ export function buildTicketTemplateProps(order = {}, seat = {}, settings = {}) {
     darkHeader: design.darkHeader,
     showPrice: ticketContent.showPrice,
     showQr: design.showQRCode,
-    showTerms: Boolean(order?.event?.note),
+    showTerms: Boolean(event.note),
     rounded: design.rounded,
     shadow: design.shadow,
     scale: settings.scale || design.scale,


### PR DESCRIPTION
## Summary
- Display event note as ticket terms and only show the section when note exists
- Carry event note through checkout and thank-you flows so PDF export can access it

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e11db3a4c8322958b680a726b5844