### PR TITLE
Use Supabase event details in checkout flow

### DIFF
--- a/src/pages/CheckoutPage.jsx
+++ b/src/pages/CheckoutPage.jsx
@@ -56,7 +56,7 @@ const CheckoutPage=()=> {
   // Load selected seats and event by ID from sessionStorage
   useEffect(()=> {
     const storedSeats=sessionStorage.getItem('selectedSeats');
-    const storedEventId=sessionStorage.getItem('eventId');
+    const storedEventData=sessionStorage.getItem('event');
 
     if (storedSeats) {
       try {
@@ -75,6 +75,15 @@ const CheckoutPage=()=> {
     } else {
       // No seats selected,redirect to home
       navigate('/');
+    }
+
+    let storedEventId=null;
+    if (storedEventData) {
+      try {
+        storedEventId=JSON.parse(storedEventData).eventId;
+      } catch (error) {
+        console.error('Error parsing stored event:',error);
+      }
     }
 
     if (storedEventId) {
@@ -359,6 +368,8 @@ const CheckoutPage=()=> {
           date: eventDetails.event_date,
           location: eventDetails.location,
           venue: eventDetails.venue,
+          note: eventDetails.note,
+          image: eventDetails.image,
         };
         sessionStorage.setItem('orderSummary', JSON.stringify({
           seats: selectedSeats.map(seat=> ({
@@ -410,6 +421,8 @@ const CheckoutPage=()=> {
           date: eventDetails.event_date,
           location: eventDetails.location,
           venue: eventDetails.venue,
+          note: eventDetails.note,
+          image: eventDetails.image,
         };
         sessionStorage.setItem('orderSummary', JSON.stringify({
           seats: selectedSeats.map(seat=> ({

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -24,6 +24,24 @@ const ThankYouPage = () => {
     }
   }, []);
 
+  // After loading order summary, fetch fresh event data for note and image
+  useEffect(() => {
+    if (orderSummary?.event?.id) {
+      fetchEventById(orderSummary.event.id)
+        .then(freshEvent => {
+          setOrderSummary(prev => ({
+            ...prev,
+            event: {
+              ...prev.event,
+              image: freshEvent.image || null,
+              note: freshEvent.note || '',
+            },
+          }));
+        })
+        .catch(err => console.error('Error fetching event details:', err));
+    }
+  }, [orderSummary?.event?.id]);
+
   // Load template settings from localStorage
   useEffect(() => {
     const storedSettings = localStorage.getItem('ticketTemplateSettings');
@@ -62,28 +80,8 @@ const ThankYouPage = () => {
 
   const handleDownload = async () => {
     if (orderSummary) {
-      let eventWithNote = { ...orderSummary.event };
-      if (orderSummary.event?.id) {
-        try {
-          const freshEvent = await fetchEventById(orderSummary.event.id);
-          eventWithNote = {
-            ...eventWithNote,
-            image: freshEvent.image || null,
-            note: freshEvent.note || '',
-          };
-        } catch (err) {
-          console.error('Error fetching event for PDF:', err);
-          eventWithNote = {
-            ...eventWithNote,
-            image: orderSummary.event?.image || null,
-            note: orderSummary.event?.note || '',
-          };
-        }
-      }
-
       const orderData = {
         ...orderSummary,
-        event: eventWithNote,
         seats: orderSummary.seats?.map(seat => ({
           ...seat,
           section: seat.section,

--- a/src/pages/VenuePage.jsx
+++ b/src/pages/VenuePage.jsx
@@ -430,8 +430,8 @@ seat_number: seat.number
 console.log('🚀 Proceeding to checkout with seats:',seatsForCheckout);
 
 // Store selected seats in sessionStorage to access them in checkout
-sessionStorage.setItem('selectedSeats',JSON.stringify(seatsForCheckout));
-sessionStorage.setItem('eventId', event.id);
+sessionStorage.setItem('selectedSeats', JSON.stringify(seatsForCheckout));
+sessionStorage.setItem('event', JSON.stringify({ eventId: event.id }));
 
 navigate('/checkout');
 }


### PR DESCRIPTION
## Summary
- Store only event ID in sessionStorage before checkout
- Fetch event data on checkout/thank-you pages to supply note and image
- Simplify ticket download flow with direct event data

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e26149ec8832294677f3141f84e78