### PR TITLE
Ensure seat identifiers render as strings in tickets

### DIFF
--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -587,7 +587,9 @@ const TicketTemplateSettings = () => {
             : undefined,
           section: lastSoldTicket.seat?.section,
           row_number: lastSoldTicket.seat?.row_number,
-          seat_number: lastSoldTicket.seat?.seat_number,
+          seat_number: lastSoldTicket.seat?.seat_number != null
+            ? String(lastSoldTicket.seat.seat_number)
+            : undefined,
           price: lastSoldTicket.order_item?.unit_price,
           label: lastSoldTicket.seat
             ? `${lastSoldTicket.seat.section} ряд ${lastSoldTicket.seat.row_number} место ${lastSoldTicket.seat.seat_number}`

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -812,10 +812,12 @@ const AdminPage = () => {
       const zone = item.ticket?.zone;
       const price = item.unit_price || item.ticket?.price;
       if (seat) {
+        const id = seat.seat_number ?? seat.label;
         return {
           section: seat.section,
           row_number: seat.row_number,
-          seat_number: seat.seat_number,
+          seat_number: id != null ? String(id) : undefined,
+          label: seat.label || (id != null ? String(id) : undefined),
           price,
           id: seat.id
         };
@@ -823,12 +825,14 @@ const AdminPage = () => {
       if (zone) {
         return {
           zone: { name: zone.name },
+          label: zone.name,
           price,
           id: zone.id
         };
       }
       return {
         zone: { name: 'Общий вход' },
+        label: 'Общий вход',
         price,
         id: item.ticket?.id
       };

--- a/src/pages/CheckoutPage.jsx
+++ b/src/pages/CheckoutPage.jsx
@@ -372,12 +372,16 @@ const CheckoutPage=()=> {
           image: eventDetails.image,
         };
         sessionStorage.setItem('orderSummary', JSON.stringify({
-          seats: selectedSeats.map(seat=> ({
-            ...seat,
-            section: seat.section,
-            row_number: seat.row_number,
-            seat_number: seat.seat_number
-          })),
+          seats: selectedSeats.map(seat => {
+            const id = seat.seat_number ?? seat.label ?? seat.zone?.name;
+            return {
+              ...seat,
+              section: seat.section,
+              row_number: seat.row_number,
+              seat_number: id != null ? String(id) : undefined,
+              label: seat.label || seat.zone?.name || (id != null ? String(id) : undefined),
+            };
+          }),
           event: eventForSummary,
           totalPrice: calculateTotal(),
           orderNumber: `TW-${order.id.substring(0,6)}`,
@@ -425,12 +429,16 @@ const CheckoutPage=()=> {
           image: eventDetails.image,
         };
         sessionStorage.setItem('orderSummary', JSON.stringify({
-          seats: selectedSeats.map(seat=> ({
-            ...seat,
-            section: seat.section,
-            row_number: seat.row_number,
-            seat_number: seat.seat_number
-          })),
+          seats: selectedSeats.map(seat => {
+            const id = seat.seat_number ?? seat.label ?? seat.zone?.name;
+            return {
+              ...seat,
+              section: seat.section,
+              row_number: seat.row_number,
+              seat_number: id != null ? String(id) : undefined,
+              label: seat.label || seat.zone?.name || (id != null ? String(id) : undefined),
+            };
+          }),
           event: eventForSummary,
           totalPrice: calculateTotal(),
           orderNumber: `TW-${order.id.substring(0,6)}`,

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -82,12 +82,16 @@ const ThankYouPage = () => {
     if (orderSummary) {
       const orderData = {
         ...orderSummary,
-        seats: orderSummary.seats?.map(seat => ({
-          ...seat,
-          section: seat.section,
-          row_number: seat.row_number,
-          seat_number: seat.seat_number
-        })),
+        seats: orderSummary.seats?.map(seat => {
+          const id = seat.seat_number ?? seat.label ?? seat.zone?.name;
+          return {
+            ...seat,
+            section: seat.section,
+            row_number: seat.row_number,
+            seat_number: id != null ? String(id) : undefined,
+            label: seat.label || seat.zone?.name || (id != null ? String(id) : undefined),
+          };
+        }),
         company: {
           name: templateSettings?.companyInfo?.brand || 'TicketWayz',
         },

--- a/src/utils/ticketExport/index.js
+++ b/src/utils/ticketExport/index.js
@@ -35,7 +35,18 @@ export function buildTicketTemplateProps(order = {}, seat = {}, settings = {}) {
     address: event.address || order.address,
     section: seatInfo.section || seatInfo.zoneName || seatInfo.zone?.name || order.section,
     row: seatInfo.row_number || order.row,
-    seat: seatInfo.seat_number || order.seat,
+    seat: (() => {
+      const seatValue = [
+        seatInfo.seat_number,
+        seatInfo.label,
+        seatInfo.seat?.seat_number,
+        seatInfo.seat?.label,
+        order.seat,
+      ].find(v => v !== undefined && v !== null);
+      return typeof seatValue === 'number' || typeof seatValue === 'string'
+        ? String(seatValue)
+        : undefined;
+    })(),
     price: seatInfo.price ?? order.price,
     currency: order.currency,
     qrValue: seatInfo.id || order.orderNumber || order.qrValue,


### PR DESCRIPTION
## Summary
- always stringify seat identifiers when building ticket props
- store string-based seat identifiers in order summaries and admin downloads
- normalize seat numbers in ticket template preview

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e309242d483228f449a5e41dfbb91