### PR TITLE
Normalize seat data in ticket preview

### DIFF
--- a/src/components/admin/TicketPreview.jsx
+++ b/src/components/admin/TicketPreview.jsx
@@ -39,6 +39,14 @@ const TicketPreview = ({
 
   const ticketRef = useRef(null);
 
+  const seatObj = typeof t.seat === 'object' ? t.seat : {};
+  const seatNumber =
+    seatObj.seat_number ??
+    seatObj.label ??
+    seatObj.number ??
+    seatObj.id ??
+    (typeof t.seat === 'string' || typeof t.seat === 'number' ? t.seat : undefined);
+
   const previewOrder = {
     date: t.date,
     time: t.time,
@@ -55,9 +63,9 @@ const TicketPreview = ({
     },
     company: { name: t.brand },
     seat: {
-      section: t.section,
-      row_number: t.row,
-      seat_number: t.seat,
+      section: t.section ?? seatObj.section,
+      row_number: t.row ?? seatObj.row_number,
+      seat_number: seatNumber != null ? String(seatNumber) : undefined,
       price: t.price,
       id: t.qrValue,
       ticketType: t.ticketType,

--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -97,7 +97,10 @@ const TicketTemplateSettings = () => {
       terms: lastSoldTicket.event?.note || '',
       section: lastSoldTicket.seat?.section,
       row: lastSoldTicket.seat?.row_number,
-      seat: lastSoldTicket.seat?.seat_number,
+      seat:
+        lastSoldTicket.seat?.seat_number != null
+          ? String(lastSoldTicket.seat.seat_number)
+          : lastSoldTicket.seat?.label,
       price: lastSoldTicket.order_item?.unit_price
         ? parseFloat(lastSoldTicket.order_item.unit_price).toFixed(2)
         : '',


### PR DESCRIPTION
## Summary
- Ensure `TicketPreview` normalizes seat objects into string seat numbers before building template props
- Convert seat numbers to strings in `TicketTemplateSettings` preview data

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e3b5a14708322b0db92bcd141935f