### PR TITLE
Bundle Roboto font for PDF template

### DIFF
--- a/src/components/ticket/TicketTemplatePDF.jsx
+++ b/src/components/ticket/TicketTemplatePDF.jsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import { Page, View, Text, Image, StyleSheet, Font } from '@react-pdf/renderer';
 import { CARD_WIDTH, HEADER_HEIGHT, sanitizeTicket } from './TicketTemplate';
+import RobotoTtf from '@/assets/fonts/Roboto-Regular.ttf';
 
-Font.register({
-  family: 'Roboto',
-  src: new URL('../../assets/fonts/Roboto-Regular.ttf', import.meta.url).href,
-  format: 'truetype',
-});
+Font.register({ family: 'Roboto', src: RobotoTtf, format: 'truetype' });
 
 const styles = StyleSheet.create({
   page: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,6 +12,7 @@ export default defineConfig({
   },
    build: {
     outDir: 'dist',
-    sourcemap: true
+    sourcemap: true,
+    assetsInlineLimit: 0,
   },
 });


### PR DESCRIPTION
## Summary
- bundle Roboto font through import and register with Font API
- ensure font assets are emitted by build

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `curl -I http://localhost:4174/assets/Roboto-Regular-B_SY1GJM.ttf`


------
https://chatgpt.com/codex/tasks/task_e_689e40c053b08322b03ae56971252182