### PR TITLE
Filter invalid ticket info nodes in TicketTemplatePDF

### DIFF
--- a/src/components/ticket/TicketTemplatePDF.jsx
+++ b/src/components/ticket/TicketTemplatePDF.jsx
@@ -172,6 +172,9 @@ const TicketTemplatePDF = ({ data = {}, options = {} }) => {
     );
   }
 
+  const filteredFirstRow = firstRow.filter(Boolean);
+  const filteredSecondRow = secondRow.filter(Boolean);
+
   return (
     <Page size="A4" style={styles.page}>
       <View style={styles.ticket}>
@@ -190,10 +193,14 @@ const TicketTemplatePDF = ({ data = {}, options = {} }) => {
           {venue && <Text style={[styles.smallText, styles.highlight]}>{venue}</Text>}
           {address && <Text style={styles.smallText}>{address}</Text>}
 
-          {(section || row || seat || (showPrice && price)) && (
+          {(filteredFirstRow.length > 0 || filteredSecondRow.length > 0) && (
             <View>
-              <View style={styles.infoRow}>{firstRow}</View>
-              <View style={styles.infoRow}>{secondRow}</View>
+              {filteredFirstRow.length > 0 && (
+                <View style={styles.infoRow}>{filteredFirstRow}</View>
+              )}
+              {filteredSecondRow.length > 0 && (
+                <View style={styles.infoRow}>{filteredSecondRow}</View>
+              )}
             </View>
           )}
 


### PR DESCRIPTION
## Summary
- avoid rendering invalid nodes in ticket info rows by filtering arrays and skipping empty rows
- prevent "Invalid '' string child outside <Text>" when generating ticket PDFs

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `rg "Invalid '' string child outside <Text>" -n /tmp/build.log`


------
https://chatgpt.com/codex/tasks/task_e_689e4c11d24883228503bbf7f47a4e6b