### PR TITLE
Handle nested seat objects in ticket templates

### DIFF
--- a/src/components/admin/TicketPreview.jsx
+++ b/src/components/admin/TicketPreview.jsx
@@ -45,6 +45,8 @@ const TicketPreview = ({
     seatObj.label ??
     seatObj.number ??
     seatObj.id ??
+    seatObj.seat?.seat_number ??
+    seatObj.seat?.label ??
     (typeof t.seat === 'string' || typeof t.seat === 'number' ? t.seat : undefined);
 
   const previewOrder = {

--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -97,10 +97,17 @@ const TicketTemplateSettings = () => {
       terms: lastSoldTicket.event?.note || '',
       section: lastSoldTicket.seat?.section,
       row: lastSoldTicket.seat?.row_number,
-      seat:
-        lastSoldTicket.seat?.seat_number != null
-          ? String(lastSoldTicket.seat.seat_number)
-          : lastSoldTicket.seat?.label,
+      seat: (() => {
+        const s = lastSoldTicket.seat;
+        const val =
+          s?.seat_number ??
+          s?.label ??
+          s?.number ??
+          s?.id ??
+          s?.seat?.seat_number ??
+          s?.seat?.label;
+        return val != null ? String(val) : undefined;
+      })(),
       price: lastSoldTicket.order_item?.unit_price
         ? parseFloat(lastSoldTicket.order_item.unit_price).toFixed(2)
         : '',
@@ -573,6 +580,14 @@ const TicketTemplateSettings = () => {
     // Ensure current settings are saved before generating preview
     await saveSettings();
 
+    const seatNum =
+      lastSoldTicket.seat?.seat_number ??
+      lastSoldTicket.seat?.label ??
+      lastSoldTicket.seat?.number ??
+      lastSoldTicket.seat?.id ??
+      lastSoldTicket.seat?.seat?.seat_number ??
+      lastSoldTicket.seat?.seat?.label;
+
     const orderData = {
       orderNumber: lastSoldTicket.order_item?.order?.id,
       company: { name: templateSettings.companyInfo?.brand || 'TicketWayz' },
@@ -590,12 +605,10 @@ const TicketTemplateSettings = () => {
             : undefined,
           section: lastSoldTicket.seat?.section,
           row_number: lastSoldTicket.seat?.row_number,
-          seat_number: lastSoldTicket.seat?.seat_number != null
-            ? String(lastSoldTicket.seat.seat_number)
-            : undefined,
+          seat_number: seatNum != null ? String(seatNum) : undefined,
           price: lastSoldTicket.order_item?.unit_price,
           label: lastSoldTicket.seat
-            ? `${lastSoldTicket.seat.section} ряд ${lastSoldTicket.seat.row_number} место ${lastSoldTicket.seat.seat_number}`
+            ? `${lastSoldTicket.seat.section} ряд ${lastSoldTicket.seat.row_number} место ${seatNum ?? ''}`
             : lastSoldTicket.zone
               ? `Зона "${lastSoldTicket.zone.name}"`
               : 'Общий вход'

--- a/src/components/ticket/TicketTemplate.jsx
+++ b/src/components/ticket/TicketTemplate.jsx
@@ -28,9 +28,13 @@ export function sanitizeTicket(data = {}) {
   for (const key of fields) {
     let val = data[key];
     if (key === 'seat' && val && typeof val === 'object') {
-      val = [val.seat_number, val.label, val.number, val.id].find(
-        (v) => v !== undefined && v !== null,
-      );
+      val =
+        val.seat_number ||
+        val.label ||
+        val.number ||
+        val.id ||
+        val.seat?.seat_number ||
+        val.seat?.label;
     }
     if (val !== undefined && val !== null) result[key] = toStr(val);
   }

--- a/src/components/ticket/TicketTemplate.test.js
+++ b/src/components/ticket/TicketTemplate.test.js
@@ -41,5 +41,13 @@ test('sanitizeTicket extracts seat identifiers', async () => {
   const { sanitizeTicket } = await loadSanitizeTicket();
   assert.equal(sanitizeTicket({ seat: { seat_number: 7 } }).seat, '7');
   assert.equal(sanitizeTicket({ seat: { label: 'VIP' } }).seat, 'VIP');
+  assert.equal(
+    sanitizeTicket({ seat: { seat: { seat_number: 9 } } }).seat,
+    '9',
+  );
+  assert.equal(
+    sanitizeTicket({ seat: { seat: { label: 'A1' } } }).seat,
+    'A1',
+  );
   assert.equal(sanitizeTicket({ seat: {} }).seat, undefined);
 });

--- a/src/components/ticket/index.js
+++ b/src/components/ticket/index.js
@@ -1,3 +1,3 @@
-export { default as TicketTemplate } from './TicketTemplate';
-export { default as TicketDesigner } from './TicketDesigner';
-export { default as TicketTemplatePDF } from './TicketTemplatePDF';
+export { default as TicketTemplate } from './TicketTemplate.jsx';
+export { default as TicketDesigner } from './TicketDesigner.jsx';
+export { default as TicketTemplatePDF } from './TicketTemplatePDF.jsx';

--- a/src/utils/ticketExport/index.js
+++ b/src/utils/ticketExport/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { pdf, Document } from '@react-pdf/renderer';
-import { TicketTemplatePDF } from '../../components/ticket';
+import { TicketTemplatePDF } from '../../components/ticket/index.js';
 
 /**
  * Build TicketTemplate props from order, seat and settings objects.
@@ -39,6 +39,8 @@ export function buildTicketTemplateProps(order = {}, seat = {}, settings = {}) {
       const seatValue = [
         seatInfo.seat_number,
         seatInfo.label,
+        seatInfo.number,
+        seatInfo.id,
         seatInfo.seat?.seat_number,
         seatInfo.seat?.label,
         order.seat,


### PR DESCRIPTION
## Summary
- normalize nested seat objects in sanitizeTicket to prevent `[object Object]` output
- reduce seat objects to strings in admin ticket preview and settings
- support additional seat fields in buildTicketTemplateProps and update ticket exports

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e4d37106483228d729caeb69fcca8