### PR TITLE
fix: remove whitespace in ticket PDF info rows

### DIFF
--- a/src/components/ticket/TicketTemplatePDF.jsx
+++ b/src/components/ticket/TicketTemplatePDF.jsx
@@ -194,14 +194,7 @@ const TicketTemplatePDF = ({ data = {}, options = {} }) => {
           {address && <Text style={styles.smallText}>{address}</Text>}
 
           {(filteredFirstRow.length > 0 || filteredSecondRow.length > 0) && (
-            <View>
-              {filteredFirstRow.length > 0 && (
-                <View style={styles.infoRow}>{filteredFirstRow}</View>
-              )}
-              {filteredSecondRow.length > 0 && (
-                <View style={styles.infoRow}>{filteredSecondRow}</View>
-              )}
-            </View>
+            <View>{filteredFirstRow.length > 0 && <View style={styles.infoRow}>{filteredFirstRow}</View>}{filteredSecondRow.length > 0 && <View style={styles.infoRow}>{filteredSecondRow}</View>}</View>
           )}
 
           {showQr && qrSrc && (


### PR DESCRIPTION
## Summary
- refactor PDF ticket info rows to avoid whitespace that triggers React PDF warnings

## Testing
- `npm run lint`
- `npm test`
- `node --input-type=module - <<'NODE'
import React from 'react';
import ReactPDF from '@react-pdf/renderer';
import TicketModule from '/tmp/TicketTemplatePDF.mjs';
const TicketTemplatePDF = TicketModule.default || TicketModule;
const data = { section: 'A', row: '1', seat: '2', price: '100', currency: 'USD', qrValue: '123' };
await ReactPDF.renderToBuffer(React.createElement(TicketTemplatePDF, { data, options: { showQr: false } }));
console.log('rendered');
NODE` *(fails: Error: Dynamic require of "stream" is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689e5934e688832280750605caca8311