### PR TITLE
refactor: split ticket info rows into columns

### DIFF
--- a/src/components/ticket/TicketTemplatePDF.jsx
+++ b/src/components/ticket/TicketTemplatePDF.jsx
@@ -193,9 +193,7 @@ const TicketTemplatePDF = ({ data = {}, options = {} }) => {
           {venue && <Text style={[styles.smallText, styles.highlight]}>{venue}</Text>}
           {address && <Text style={styles.smallText}>{address}</Text>}
 
-          {(filteredFirstRow.length > 0 || filteredSecondRow.length > 0) && (
-            <View>{filteredFirstRow.length > 0 && <View style={styles.infoRow}>{filteredFirstRow}</View>}{filteredSecondRow.length > 0 && <View style={styles.infoRow}>{filteredSecondRow}</View>}</View>
-          )}
+          {(filteredFirstRow.length > 0 || filteredSecondRow.length > 0) && (<View style={{ flexDirection: 'row' }}><View style={{ flex: 1, borderRightWidth: 1, borderColor: 'transparent', alignItems: 'flex-start' }}>{filteredFirstRow}</View><View style={{ flex: 1, borderLeftWidth: 1, borderColor: 'transparent', alignItems: 'flex-end' }}>{filteredSecondRow}</View></View>)}
 
           {showQr && qrSrc && (
             <View style={styles.qrContainer}>


### PR DESCRIPTION
## Summary
- render ticket info rows using left/right columns without intermediate whitespace

## Testing
- `npm run lint`
- `npm test`
- `node render.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689e6574a1988322ab4c823d3b75823d