### PR TITLE
Handle seat objects in ticket exports and sanitization

### DIFF
--- a/src/components/ticket/TicketTemplate.jsx
+++ b/src/components/ticket/TicketTemplate.jsx
@@ -34,7 +34,8 @@ export function sanitizeTicket(data = {}) {
         val.number ||
         val.id ||
         val.seat?.seat_number ||
-        val.seat?.label;
+        val.seat?.label ||
+        '';
     }
     if (val !== undefined && val !== null) result[key] = toStr(val);
   }

--- a/src/components/ticket/TicketTemplate.test.js
+++ b/src/components/ticket/TicketTemplate.test.js
@@ -49,5 +49,5 @@ test('sanitizeTicket extracts seat identifiers', async () => {
     sanitizeTicket({ seat: { seat: { label: 'A1' } } }).seat,
     'A1',
   );
-  assert.equal(sanitizeTicket({ seat: {} }).seat, undefined);
+  assert.equal(sanitizeTicket({ seat: {} }).seat, '');
 });

--- a/src/utils/ticketExport/index.js
+++ b/src/utils/ticketExport/index.js
@@ -45,9 +45,14 @@ export function buildTicketTemplateProps(order = {}, seat = {}, settings = {}) {
         seatInfo.seat?.label,
         order.seat,
       ].find(v => v !== undefined && v !== null);
-      return typeof seatValue === 'number' || typeof seatValue === 'string'
-        ? String(seatValue)
-        : undefined;
+      if (typeof seatValue === 'number' || typeof seatValue === 'string') {
+        return String(seatValue);
+      }
+      if (seatValue && typeof seatValue === 'object') {
+        const nested = seatValue.label || seatValue.id;
+        return nested != null ? String(nested) : undefined;
+      }
+      return undefined;
     })(),
     price: seatInfo.price ?? order.price,
     currency: order.currency,


### PR DESCRIPTION
## Summary
- stringify object `seat` values in `buildTicketTemplateProps`
- ensure `sanitizeTicket` reduces seat objects to a string
- align tests with updated seat sanitization

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e6ff40084832291bcf1f4c59c30b7