### PR TITLE
Avoid empty string defaults in ticket PDF generation

### DIFF
--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -88,13 +88,13 @@ const TicketTemplateSettings = () => {
     }
     return {
       brand: templateSettings.companyInfo?.brand || 'TicketWayz',
-      heroImage: templateSettings.design?.heroUrl || lastSoldTicket.event?.image || '',
-      artist: lastSoldTicket.event?.title || '',
+      heroImage: templateSettings.design?.heroUrl || lastSoldTicket.event?.image || undefined,
+      artist: lastSoldTicket.event?.title || undefined,
       date: eventDate,
       time: eventTime,
-      venue: lastSoldTicket.event?.location || '',
-      address: lastSoldTicket.event?.address || '',
-      terms: lastSoldTicket.event?.note || '',
+      venue: lastSoldTicket.event?.location || undefined,
+      address: lastSoldTicket.event?.address || undefined,
+      terms: lastSoldTicket.event?.note || undefined,
       section: lastSoldTicket.seat?.section,
       row: lastSoldTicket.seat?.row_number,
       seat: (() => {
@@ -110,11 +110,11 @@ const TicketTemplateSettings = () => {
       })(),
       price: lastSoldTicket.order_item?.unit_price
         ? parseFloat(lastSoldTicket.order_item.unit_price).toFixed(2)
-        : '',
+        : undefined,
       currency: '€',
       qrValue: lastSoldTicket.id
         ? `T-${lastSoldTicket.id.substring(0, 8)}`
-        : '',
+        : undefined,
       ticketType: lastSoldTicket.seat
         ? 'seat'
         : lastSoldTicket.zone

--- a/src/components/ticket/TicketTemplatePDF.jsx
+++ b/src/components/ticket/TicketTemplatePDF.jsx
@@ -179,33 +179,33 @@ const TicketTemplatePDF = ({ data = {}, options = {} }) => {
     <Page size="A4" style={styles.page}>
       <View style={styles.ticket}>
         <View style={styles.hero}>
-          {heroImage && <Image src={heroImage} style={styles.heroImage} />}
-          {brand && <Text style={styles.brand}>{brand}</Text>}
+          {heroImage ? <Image src={heroImage} style={styles.heroImage} /> : null}
+          {brand ? <Text style={styles.brand}>{brand}</Text> : null}
         </View>
         <View style={styles.content}>
-          {artist && <Text style={styles.heading}>{artist}</Text>}
-          {(date || time) && (
+          {artist ? <Text style={styles.heading}>{artist}</Text> : null}
+          {(date || time) ? (
             <Text style={styles.smallText}>
               {date}
               {time ? ` ${time}` : ''}
             </Text>
-          )}
-          {venue && <Text style={[styles.smallText, styles.highlight]}>{venue}</Text>}
-          {address && <Text style={styles.smallText}>{address}</Text>}
+          ) : null}
+          {venue ? <Text style={[styles.smallText, styles.highlight]}>{venue}</Text> : null}
+          {address ? <Text style={styles.smallText}>{address}</Text> : null}
 
-          {(filteredFirstRow.length > 0 || filteredSecondRow.length > 0) && (<View style={{ flexDirection: 'row' }}><View style={{ flex: 1, borderRightWidth: 1, borderColor: 'transparent', alignItems: 'flex-start' }}>{filteredFirstRow}</View><View style={{ flex: 1, borderLeftWidth: 1, borderColor: 'transparent', alignItems: 'flex-end' }}>{filteredSecondRow}</View></View>)}
+          {(filteredFirstRow.length > 0 || filteredSecondRow.length > 0) ? (<View style={{ flexDirection: 'row' }}><View style={{ flex: 1, borderRightWidth: 1, borderColor: 'transparent', alignItems: 'flex-start' }}>{filteredFirstRow}</View><View style={{ flex: 1, borderLeftWidth: 1, borderColor: 'transparent', alignItems: 'flex-end' }}>{filteredSecondRow}</View></View>) : null}
 
-          {showQr && qrSrc && (
+          {showQr && qrSrc ? (
             <View style={styles.qrContainer}>
               <Image style={styles.qr} src={qrSrc} />
-              {actualTicketId && <Text style={styles.ticketId}>{actualTicketId}</Text>}
+              {actualTicketId ? <Text style={styles.ticketId}>{actualTicketId}</Text> : null}
             </View>
-          )}
-          {qrValue && actualTicketId && qrValue !== actualTicketId && (
+          ) : null}
+          {qrValue && actualTicketId && qrValue !== actualTicketId ? (
             <Text style={styles.ticketId}>{qrValue}</Text>
-          )}
+          ) : null}
 
-          {terms && <Text style={styles.terms}>{terms}</Text>}
+          {terms ? <Text style={styles.terms}>{terms}</Text> : null}
         </View>
       </View>
     </Page>

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -34,7 +34,7 @@ const ThankYouPage = () => {
             event: {
               ...prev.event,
               image: freshEvent.image || null,
-              note: freshEvent.note || '',
+              note: freshEvent.note || null,
             },
           }));
         })

--- a/src/utils/ticketExport/index.js
+++ b/src/utils/ticketExport/index.js
@@ -58,7 +58,7 @@ export function buildTicketTemplateProps(order = {}, seat = {}, settings = {}) {
     currency: order.currency,
     qrValue: seatInfo.id || order.orderNumber || order.qrValue,
     ticketType: seatInfo.ticketType || seatInfo.type || order.ticketType,
-    terms: event.note || '',
+    terms: event.note ? event.note : undefined,
   };
 
   const options = {


### PR DESCRIPTION
## Summary
- stop defaulting `terms` to empty string in ticket export
- use explicit conditionals in TicketTemplatePDF to avoid accidental string rendering
- remove empty-string fallbacks when loading event notes for tickets and settings preview

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e75330024832296269a928350282b