### PR TITLE
refactor: import roboto font asset

### DIFF
--- a/src/components/ticket/TicketTemplatePDF.jsx
+++ b/src/components/ticket/TicketTemplatePDF.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Page, View, Text, Image, StyleSheet, Font } from '@react-pdf/renderer';
 import { CARD_WIDTH, HEADER_HEIGHT, sanitizeTicket } from './TicketTemplate';
+import robotoTtf from '../../assets/fonts/Roboto-Regular.ttf?url';
 
-const robotoTtf = new URL('../../assets/fonts/Roboto-Regular.ttf', import.meta.url).href;
 Font.register({ family: 'Roboto', src: robotoTtf, format: 'truetype' });
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Summary
- import Roboto TTF asset via Vite URL query
- register Roboto font using imported asset

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a04b86de7883228196158bef9104a4