### PR TITLE
Handle Roboto font registration errors

### DIFF
--- a/src/components/ticket/TicketTemplatePDF.jsx
+++ b/src/components/ticket/TicketTemplatePDF.jsx
@@ -3,7 +3,13 @@ import { Page, View, Text, Image, StyleSheet, Font } from '@react-pdf/renderer';
 import { CARD_WIDTH, HEADER_HEIGHT, sanitizeTicket } from './TicketTemplate';
 import robotoTtf from '../../assets/fonts/Roboto-Regular.ttf?url';
 
-Font.register({ family: 'Roboto', src: robotoTtf, format: 'truetype' });
+let fontFamily = 'Helvetica';
+try {
+  Font.register({ family: 'Roboto', src: robotoTtf, format: 'truetype' });
+  fontFamily = 'Roboto';
+} catch (err) {
+  console.error('Failed to register Roboto font', err);
+}
 
 const styles = StyleSheet.create({
   page: {
@@ -42,7 +48,7 @@ const styles = StyleSheet.create({
     paddingVertical: 2,
     fontSize: 12,
     borderRadius: 4,
-    fontFamily: 'Roboto',
+    fontFamily,
   },
   content: {
     padding: 24,
@@ -51,13 +57,13 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: 'bold',
     marginBottom: 4,
-    fontFamily: 'Roboto',
+    fontFamily,
   },
   smallText: {
     fontSize: 12,
     color: '#4b5563',
     marginBottom: 2,
-    fontFamily: 'Roboto',
+    fontFamily,
   },
   highlight: {
     color: '#f59e0b',
@@ -73,13 +79,13 @@ const styles = StyleSheet.create({
   infoLabel: {
     fontSize: 10,
     color: '#6b7280',
-    fontFamily: 'Roboto',
+    fontFamily,
   },
   infoValue: {
     fontSize: 16,
     fontWeight: 'bold',
     color: '#f59e0b',
-    fontFamily: 'Roboto',
+    fontFamily,
   },
   qrContainer: {
     marginTop: 24,
@@ -94,7 +100,7 @@ const styles = StyleSheet.create({
     color: '#6b7280',
     marginTop: 4,
     textAlign: 'center',
-    fontFamily: 'Roboto',
+    fontFamily,
   },
   terms: {
     marginTop: 24,
@@ -104,7 +110,7 @@ const styles = StyleSheet.create({
     paddingTop: 12,
     fontSize: 10,
     color: '#6b7280',
-    fontFamily: 'Roboto',
+    fontFamily,
   },
 });
 


### PR DESCRIPTION
## Summary
- wrap Roboto `Font.register` call in a try/catch to gracefully handle failures
- log registration errors and fall back to a default system font when Roboto is unavailable

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a04c93d0f883229401c024a65d587a