### PR TITLE
fix: resolve event image preview

### DIFF
--- a/src/components/events/EventWizard.jsx
+++ b/src/components/events/EventWizard.jsx
@@ -412,21 +412,24 @@ const EventWizard = ({ onCancel, eventToEdit = null, onEventSaved }) => {
       };
 
       console.log("Formatted event data:", formattedEventData);
-      setEventData(formattedEventData);
 
+      // Determine preview URL while keeping the stored path
+      let previewUrl = 'https://placehold.co/600x400/333/FFF?text=Event';
       if (formattedEventData.image) {
         if (formattedEventData.image.startsWith('http')) {
-          setPreviewUrl(formattedEventData.image);
+          previewUrl = formattedEventData.image;
         } else {
           const { data: { publicUrl } } = supabase
             .storage
             .from('event-images')
             .getPublicUrl(formattedEventData.image);
-          setPreviewUrl(publicUrl);
+          previewUrl = publicUrl;
         }
-      } else {
-        setPreviewUrl('https://placehold.co/600x400/333/FFF?text=Event');
       }
+
+      // Store only the path while using the public URL for the preview
+      setEventData(formattedEventData);
+      setPreviewUrl(previewUrl);
 
       // Fetch event prices if we have an event ID
       if (event.id) {


### PR DESCRIPTION
## Summary
- ensure event image paths resolve to a public URL without altering stored value

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1ee2cf3b88322b4f1cce7ed9cb1d6