### PR TITLE
feat: verify unique tickets before order creation

### DIFF
--- a/src/pages/CheckoutPage.jsx
+++ b/src/pages/CheckoutPage.jsx
@@ -219,6 +219,13 @@ const CheckoutPage=()=> {
         throw new Error('Нет выбранных мест для заказа');
       }
 
+      // Собираем все ticket IDs и проверяем на дубликаты до обращения к БД
+      const allTicketIds=selectedSeats.flatMap(seat=> seat.ticketIds || [seat.ticketId]).filter(Boolean);
+      const uniqueIds=new Set(allTicketIds);
+      if (uniqueIds.size !== allTicketIds.length) {
+        throw new Error('Обнаружены дублирующиеся билеты среди выбранных мест');
+      }
+
       // 1. Создаем или получаем пользователя с реальными данными
       const userId=await createOrGetUser();
       console.log('✅ User ID:',userId);


### PR DESCRIPTION
## Summary
- gather all ticket IDs from selected seats before hitting the database
- detect duplicate tickets with a Set and abort order creation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1f4ba8a448322b9c668907a3b0929