### PR TITLE
fix: avoid 406 when user email not found

### DIFF
--- a/src/pages/CheckoutPage.jsx
+++ b/src/pages/CheckoutPage.jsx
@@ -153,14 +153,14 @@ const CheckoutPage=()=> {
       // Генерируем новый UUID для каждого пользователя
       const userId=crypto.randomUUID();
 
-      // Проверяем,существует ли уже пользователь с таким email
-      const {data: existingUser,error: checkError}=await supabase
+      // Проверяем, существует ли уже пользователь с таким email
+      const {data: existingUser, error: checkError} = await supabase
         .from('user_meta')
         .select('id')
-        .eq('email',formData.email.trim())
-        .single();
+        .eq('email', formData.email.trim())
+        .maybeSingle();
 
-      if (checkError && checkError.code !=='PGRST116') {// PGRST116=no rows found
+      if (checkError) {
         throw checkError;
       }
 
@@ -183,6 +183,7 @@ const CheckoutPage=()=> {
         console.log('Updated existing user:',updatedUser);
         return existingUser.id;
       } else {
+        // existingUser === null -> создаем нового пользователя
         // Создаем нового пользователя с реальными данными из формы
         const {data: newUser,error: createError}=await supabase
           .from('user_meta')


### PR DESCRIPTION
## Summary
- use `maybeSingle` when looking up existing user in checkout
- handle missing user and create new record seamlessly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a220244e248322aef30448f0d16bab