### PR TITLE
Remove deprecated 'available' ticket status

### DIFF
--- a/src/components/venue/VenueSeatingChart.jsx
+++ b/src/components/venue/VenueSeatingChart.jsx
@@ -373,7 +373,7 @@ if (purchasedSeats.find(s => s.seat_id === seatId)) return 'purchased';
 if (reservedSeats.find(s => s.seat_id === seatId)) return 'reserved';
 // ИСПРАВЛЕНО: Проверяем выбранные кресла по правильному полю seatId
 if (selectedSeats.find(s => s.seatId === seatId)) return 'selected';
-return 'available';
+return 'free';
 }, [reservedSeats, purchasedSeats, selectedSeats]);
 
 const getSeatColor=useCallback((seat,status)=> {
@@ -381,7 +381,7 @@ switch (status) {
 case 'purchased': return '#6B7280';// Gray
 case 'reserved': return '#F59E0B';// Amber
 case 'selected': return '#10B981';// Green
-case 'available':
+case 'free':
 default:
 // Use category color if available
 if (seat.categoryId && categories[seat.categoryId]) {
@@ -448,7 +448,7 @@ ticketStatuses: relevantTickets.map(t=> t.status)
 });
 
 // Подсчитываем билеты по статусам
-const freeTickets=relevantTickets.filter(t=> t.status==='free' || t.status==='available');
+const freeTickets=relevantTickets.filter(t=> t.status==='free');
 const heldTickets=relevantTickets.filter(t=> t.status==='held');
 const soldTickets=relevantTickets.filter(t=> t.status==='sold');
 
@@ -828,7 +828,7 @@ return isPointInElement(pos,element);
 
 if (clickedSeat) {
 const status=getSeatStatus(clickedSeat.id);
-if (status==='available' || status==='selected') {
+if (status==='free' || status==='selected') {
 onSeatSelect?.(clickedSeat);
 }
 return;

--- a/src/pages/VenuePage.jsx
+++ b/src/pages/VenuePage.jsx
@@ -164,7 +164,7 @@ console.log('🔍 ПОИСК БИЛЕТОВ для места/зоны:',seat);
 console.log('🔍 Доступные билеты:',tickets.length);
 
 // Фильтруем только свободные билеты
-const freeTickets=tickets.filter(t=> t.status==='free' || t.status==='available');
+const freeTickets=tickets.filter(t=> t.status==='free');
 console.log('🔍 Свободные билеты:',freeTickets.length);
 
 if (seat.type==='seat') {
@@ -496,10 +496,10 @@ getSeatPrice(selectedCapacityElement).then(unitPrice=> {
 console.log(`Got unit price for capacity selection: ${unitPrice}`);
 
 // Найти доступные билеты для этой зоны
-const availableTicketsForZone=tickets.filter(t=> 
-t.zone_id===selectedCapacityElement.id && 
-(t.status==='free' || t.status==='available')
-);
+const availableTicketsForZone=tickets.filter(t=>
+        t.zone_id===selectedCapacityElement.id &&
+        t.status==='free'
+      );
 
 if (availableTicketsForZone.length < capacityToSelect) {
 alert('Недостаточно доступных билетов для выбранного количества мест');

--- a/src/services/ticketService.js
+++ b/src/services/ticketService.js
@@ -116,7 +116,7 @@ export const getAvailableTickets = async (eventId) => {
         )
       `)
       .eq('event_id', eventId)
-      .in('status', ['free', 'available']) // Используем правильные статусы
+      .eq('status', 'free')
       .order('created_at');
 
     if (error) throw error;
@@ -140,7 +140,7 @@ export const getTicketsStatistics = async (eventId) => {
 
     const stats = {
       total: data.length,
-      available: data.filter(t => t.status === 'free' || t.status === 'available').length,
+      available: data.filter(t => t.status === 'free').length,
       held: data.filter(t => t.status === 'held').length,
       sold: data.filter(t => t.status === 'sold').length
     };
@@ -165,7 +165,7 @@ export const holdTickets = async (ticketIds, holdDuration = 15) => {
         updated_at: new Date().toISOString()
       })
       .in('id', ticketIds)
-      .in('status', ['free', 'available'])
+      .eq('status', 'free')
       .select();
 
     if (error) throw error;


### PR DESCRIPTION
## Summary
- Fetch only `free` tickets and update stats/holds to drop deprecated `available` status
- Adjust venue page and seating chart to use `status === 'free'` when checking ticket availability

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a225634f50832284c650da50011968