### PR TITLE
Grant execute permission for create_order_with_items

### DIFF
--- a/migrations/20240914_create_order_rpc.sql
+++ b/migrations/20240914_create_order_rpc.sql
@@ -68,3 +68,5 @@ EXCEPTION
         END IF;
 END;
 $$;
+
+GRANT EXECUTE ON FUNCTION public.create_order_with_items(uuid, jsonb, numeric, text) TO anon, authenticated;


### PR DESCRIPTION
## Summary
- allow anon and authenticated roles to execute create_order_with_items RPC

## Testing
- `npm test`
- `npm run lint`
- Attempted `supabase migration up` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a237b5f304832282b1a0b1acb61f51