### PR TITLE
Use RPC for partial event deletion

### DIFF
--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -1260,15 +1260,13 @@ const AdminPage = () => {
           await loadEvents();
         }
       } else if (action === 'partial') {
-        const success = await deleteEventPartial(eventToDelete);
-        if (success !== false) {
-          setEvents((prev) =>
-            prev.map(event =>
-              event.id === eventToDelete ? { ...event, status: 'partial' } : event
-            )
-          );
-          await loadEvents();
-        }
+        await deleteEventPartial(eventToDelete);
+        setEvents((prev) =>
+          prev.map(event =>
+            event.id === eventToDelete ? { ...event, status: 'partial' } : event
+          )
+        );
+        await loadEvents();
       } else if (action === 'cascade') {
         const success = await deleteEventCascade(eventToDelete, true);
         if (success !== false) {


### PR DESCRIPTION
## Summary
- Call `hasEventOrderItems` before deleting tickets and use `delete_event_partial` RPC to prune unsold data
- Surface deletion error messages on the admin page
- Test partial deletion early abort and RPC invocation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a489ec3ca48322ac0fce7cae89d637