### PR TITLE
Run migration for delete_event_cascade and add RPC fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "npm run lint && vite build",
+    "build": "npm run lint && npm run migrate && vite build",
     "lint": "eslint .",
     "lint:error": "eslint . --quiet",
     "test": "node --test",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "migrate": "supabase db push"
   },
   "dependencies": {
     "@questlabs/react-sdk": "^2.2.4",


### PR DESCRIPTION
## Summary
- ensure build runs Supabase migrations so delete_event_cascade is available
- add transactional fallback when delete_event_cascade RPC is missing

## Testing
- `npm test` *(fails: Invalid URL)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a48b3ae2c8832284b56b96575ad016