### PR TITLE
refactor: rename delete_event_cascade argument

### DIFF
--- a/migrations/20241024_create_delete_event_cascade.sql
+++ b/migrations/20241024_create_delete_event_cascade.sql
@@ -1,5 +1,5 @@
 -- Ensure cascading delete of an event and related data
-CREATE OR REPLACE FUNCTION delete_event_cascade(event_id uuid)
+CREATE OR REPLACE FUNCTION delete_event_cascade(p_event_id uuid)
 RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
@@ -8,17 +8,17 @@ BEGIN
     -- Remove order items associated with event tickets
     DELETE FROM order_items
     WHERE ticket_id IN (
-        SELECT id FROM tickets WHERE event_id = delete_event_cascade.event_id
+        SELECT id FROM tickets WHERE event_id = p_event_id
     );
 
     -- Remove tickets for the event
-    DELETE FROM tickets WHERE event_id = delete_event_cascade.event_id;
+    DELETE FROM tickets WHERE event_id = p_event_id;
 
     -- Remove event prices
-    DELETE FROM event_prices WHERE event_id = delete_event_cascade.event_id;
+    DELETE FROM event_prices WHERE event_id = p_event_id;
 
     -- Finally remove the event itself
-    DELETE FROM events WHERE id = delete_event_cascade.event_id;
+    DELETE FROM events WHERE id = p_event_id;
 END;
 $$;
 


### PR DESCRIPTION
## Summary
- rename delete_event_cascade argument to `p_event_id`
- reference `p_event_id` throughout delete cascade function

## Testing
- `npm run lint`
- `npm test` *(fails: delete_event_cascade function missing)*
- `npm run migrate` *(fails: supabase: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a497728df483229c57d71a6d2b5fcc