### PR TITLE
Use p_event_id for event deletion RPC

### DIFF
--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -454,7 +454,7 @@ export const deleteEventPartial = async (eventId) => {
   try {
     // Rely on database logic to handle sold tickets
     const { data, error } = await supabase.rpc('delete_event_partial', {
-      event_id: eventId
+      p_event_id: eventId
     });
 
     if (error) {
@@ -484,7 +484,7 @@ export const deleteEventCascade = async (eventId, force = false) => {
     }
 
     const { data, error } = await supabase.rpc('delete_event_cascade', {
-      event_id: eventId
+      p_event_id: eventId
     });
 
     if (error) {

--- a/src/services/eventService.test.js
+++ b/src/services/eventService.test.js
@@ -234,7 +234,7 @@ test('deleteEventPartial calls RPC without checking sold tickets', async (t) => 
   assert.equal(fromCalled, 0);
   assert.equal(rpcCalled, 1);
   assert.equal(rpcArgs.name, 'delete_event_partial');
-  assert.deepEqual(rpcArgs.args, { event_id: 1 });
+  assert.deepEqual(rpcArgs.args, { p_event_id: 1 });
   assert.equal(result, true);
 
   delete global.__mockSupabase;


### PR DESCRIPTION
## Summary
- Use `p_event_id` when calling `delete_event_partial` and `delete_event_cascade`
- Align service tests with new RPC parameter name

## Testing
- `npm test` *(fails: Invalid package.json)*
- `node --test` *(fails: Expected double-quoted property name in JSON at position 295)*
- `npx eslint .` *(fails: Invalid package config /workspace/TicketWayzV3/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ccc70ba483229b8ddda18aa85810