### PR TITLE
Add Supabase environment example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL="https://your-project-id.supabase.co"
+VITE_SUPABASE_ANON_KEY="public-anon-key"

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ This project uses [Vite](https://vitejs.dev/) for development and the built-in N
    ```bash
    npm install
    ```
-3. Copy `.env.example` to `.env.local` and set your Supabase credentials:
+3. Copy `.env.example` to `.env.local` and replace the placeholder values with your Supabase credentials:
    ```bash
    cp .env.example .env.local
-   # then edit .env.local
-   VITE_SUPABASE_URL="https://your-project.supabase.co"
+   # then edit .env.local and update with your real values
+   VITE_SUPABASE_URL="https://your-project-id.supabase.co"
    VITE_SUPABASE_ANON_KEY="public-anon-key"
    ```
 


### PR DESCRIPTION
## Summary
- add Supabase environment variable template
- document copying `.env.example` to `.env.local` with real credentials

## Testing
- `npm test` *(fails: Invalid package.json: Expected double-quoted property name in JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d182c87483229fac5084c6b246ff